### PR TITLE
Add an ansible playbook for "all-in-one" deployment

### DIFF
--- a/ansible/all-in-one/README.md
+++ b/ansible/all-in-one/README.md
@@ -1,0 +1,50 @@
+All-in-one deployment of XSnippet
+=================================
+
+Deploys both [xsnippet-api](https://github.com/xsnippet/xsnippet-api) web-service
+and [xsnippet-web](https://github.com/xsnippet/xsnippet-web) SPA on *one* host
+under different *server names* (i.e. domains).
+
+Docker Swarm [stack](https://docs.docker.com/get-started/part5/) is used to spawn
+and manage all the required services:
+
+  1. ``xsnippet-api`` Python-powered web-service.
+  2. ``mongodb`` database - main storage for application data.
+  3. ``nginx`` webserver - used both as a webserver for serving static content
+     of the SPA and as a reverse-proxy for the Python application.
+
+The only reason behind using of Docker Swarm is the support for *stacks*, that
+allows to declaratively describe the deployed infrastructure similarly to
+docker-compose configurations.
+
+The given playbook is meant to be executed against Debian'ish hosts and was
+tested on the latest Ubuntu LTS version (currently, Xenial).
+
+
+Usage
+=====
+
+The very same command is used to perform both initial deployments and upgrades:
+
+
+```shell
+
+    # ansible-playbook -i path_to_inventory deploy.yaml
+
+```
+
+
+Important variables
+===================
+
+Most likely you'll need to override the defaults of the following variables
+defined in the playbook:
+
+    # ``xsnippet_api_server_name``: server name of the API in the config of the webserver
+    # ``xsnippet_spa_server_name``: server name of the SPA in the config of the webserver
+    # ``xsnippet_api_image``: Docker image of the API to be used
+    # ``xsnippet_web_assets``: URL of the SPA tarball release to be used
+
+Note, that Docker images of ``xsnippet-api`` are periodically pushed to
+[Docker Hub](https://hub.docker.com/r/xsnippet/xsnippet-api/), and SPA assets are released
+on [GitHub](https://github.com/xsnippet/xsnippet-web/releases).

--- a/ansible/all-in-one/configs/xsnippet-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-api.conf.j2
@@ -1,0 +1,201 @@
+[server]
+
+; IP ADDRESS TO LISTEN ON
+;
+; By default, only localhost interface is used for listening. That's
+; why no requests from outer world will be handled. If you want to
+; accept any incoming request on any interface, please change that
+; value to '0.0.0.0'.
+host = 0.0.0.0
+
+; PORT TO LISTEN ON
+;
+; In production you probably will choose a default HTTP port - '80'.
+; If you want to pick any random free port, just pass '0'.
+port = 8000
+
+
+[database]
+
+; DATABASE CONNECTION URI
+;
+; Supported backends: MongoDB only
+connection = mongodb://db:27017/xsnippet
+
+
+[snippet]
+
+; LIST OF ALLOWED SYNTAXES
+;
+; Set constraint on 'snippet.syntax' property. Each syntax should come
+; on separate line. E.g:
+;
+;    syntaxes =
+;        cpp
+;        python
+;        javascript
+;
+
+syntaxes =
+    APL
+    ASN.1
+    ASP.NET
+    Asterisk
+    Brainfuck
+    C
+    C#
+    C++
+    CMake
+    CQL
+    CSS
+    Clojure
+    ClojureScript
+    Closure Stylesheets (GSS)
+    Cobol
+    CoffeeScript
+    Common Lisp
+    Crystal
+    Cypher
+    Cython
+    D
+    DTD
+    Dart
+    Django
+    Dockerfile
+    Dylan
+    EBNF
+    ECL
+    Eiffel
+    Elm
+    Embedded Javascript
+    Embedded Ruby
+    Erlang
+    Esper
+    F#
+    FCL
+    Factor
+    Forth
+    Fortran
+    Gas
+    Gherkin
+    GitHub Flavored Markdown
+    Go
+    Groovy
+    HAML
+    HTML
+    HTTP
+    HXML
+    Haskell
+    Haskell (Literate)
+    Haxe
+    IDL
+    JSON
+    JSON-LD
+    JSX
+    Java
+    Java Server Pages
+    JavaScript
+    Jinja2
+    Julia
+    Kotlin
+    LESS
+    LaTeX
+    LiveScript
+    Lua
+    MS SQL
+    MUMPS
+    MariaDB SQL
+    Markdown
+    Mathematica
+    Modelica
+    MySQL
+    NSIS
+    NTriples
+    Nginx
+    OCaml
+    Objective-C
+    Octave
+    Oz
+    PEG.js
+    PGP
+    PHP
+    PLSQL
+    Pascal
+    Perl
+    Pig
+    Plain Text
+    PowerShell
+    Properties files
+    ProtoBuf
+    Pug
+    Puppet
+    Python
+    Q
+    R
+    RPM Changes
+    RPM Spec
+    Ruby
+    Rust
+    SAS
+    SCSS
+    SPARQL
+    SQL
+    SQLite
+    Sass
+    Scala
+    Scheme
+    Shell
+    Sieve
+    Slim
+    Smalltalk
+    Smarty
+    Solr
+    Soy
+    Spreadsheet
+    Squirrel
+    Stylus
+    Swift
+    SystemVerilog
+    TOML
+    TTCN
+    TTCN_CFG
+    Tcl
+    Textile
+    TiddlyWiki
+    Tiki wiki
+    Tornado
+    Turtle
+    Twig
+    TypeScript
+    TypeScript-JSX
+    VB.NET
+    VBScript
+    VHDL
+    Velocity
+    Verilog
+    Vue.js Component
+    Web IDL
+    XML
+    XQuery
+    YAML
+    Yacas
+    Z80
+    diff
+    edn
+    mIRC
+    mbox
+    mscgen
+    msgenny
+    reStructuredText
+    sTeX
+    troff
+    xu
+
+
+[auth]
+
+; SECRET KEY TO BE USED FOR VALIDATION OF SIGNED TOKENS
+;
+; If not set, it will be generated automatically for this run of application.
+; Set the value explicitly, so that it's preserved between runs.
+secret =

--- a/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
@@ -1,0 +1,28 @@
+upstream xsnippet_api {
+    server api:8000;
+}
+
+server {
+    listen 80;
+
+    server_name {{ xsnippet_api_server_name }};
+
+    location / {
+        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+        add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+
+        if ($request_method = 'OPTIONS') {
+           add_header 'Access-Control-Allow-Origin' '*';
+           add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+           add_header 'Access-Control-Max-Age' 1728000;
+           add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+           add_header 'Content-Type' 'text/plain; charset=utf-8';
+           add_header 'Content-Length' 0;
+           return 204;
+        }
+
+        proxy_pass http://xsnippet_api;
+    }
+}

--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    server_name {{ xsnippet_spa_server_name }};
+
+    root /www/data;
+
+    location / {
+        error_page 404 =200 /index.html;
+
+        index index.html;
+    }
+}

--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -1,0 +1,120 @@
+---
+- hosts: xsnippet
+  tasks:
+    - name: ensure Python 2 is installed
+      raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+      become: true
+  gather_facts: false
+
+- hosts: xsnippet
+  become: true
+  tasks:
+    - name: update apt cache (if needed)
+      apt: update_cache=yes cache_valid_time=3600
+
+    - name: install essential packages
+      apt: "name={{ item }} state=latest"
+      with_items:
+        - apt-transport-https
+        - ca-certificates
+
+    - name: add Docker gpg key
+      apt_key:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        state: present
+
+    - name: add Docker packages repo
+      apt_repository:
+        repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+      register: newrepo
+
+    - name: update apt cache (if needed)
+      apt: update_cache=yes
+      when: newrepo.changed
+
+    - name: install the latest Docker
+      apt: name=docker-ce state=latest
+
+    - name: initialize Docker Swarm
+      shell: "docker swarm init --advertise-addr 127.0.0.1 || docker stack ls"
+      register: init_result
+      changed_when: "'This node is already part of a swarm' not in init_result.stderr"
+
+    - name: create xsnippet user
+      user:
+        name: xsnippet
+        createhome: yes
+        append: true
+        groups: docker
+
+- hosts: xsnippet
+  vars:
+    # nginx will be configured to serve both API and SPA on the same port (80) under different server names
+    xsnippet_api_server_name: api.xsnippet.org
+    xsnippet_spa_server_name: beta.xsnippet.org
+    # versions of API and SPA to be used
+    xsnippet_api_image: xsnippet/xsnippet-api:68be785
+    xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/alpha-2/xsnippet_web-alpha-2.tar.gz
+  become: true
+  become_user: xsnippet
+  tasks:
+    - file:
+        path: "/home/xsnippet/xsnippet-web"
+        state: directory
+
+    - name: prepare xsnippet-web assets
+      unarchive:
+        src: "{{ xsnippet_web_assets }}"
+        dest: "/home/xsnippet/xsnippet-web"
+        remote_src: yes
+
+    - name: prepare the config file
+      template:
+        src: configs/xsnippet-api.conf.j2
+        dest: "/home/xsnippet/xsnippet-api.conf"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    - name: prepare the webserver config for API
+      template:
+        src:  configs/xsnippet-webserver-api.conf.j2
+        dest: "/home/xsnippet/xsnippet-webserver-api.conf"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    - name: prepare the webserver config for SPA
+      template:
+        src:  configs/xsnippet-webserver-spa.conf.j2
+        dest: "/home/xsnippet/xsnippet-webserver-spa.conf"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    - name: prepare the Docker stack config
+      template:
+        src: docker/stack.yml.j2
+        dest: "/home/xsnippet/stack.yml"
+        mode: 0600
+        owner: xsnippet
+        group: xsnippet
+
+    # The only reason we need to remove the stack first is the fact, that configs in Docker Swarm
+    # are "immutable" and are not updated when the corresponding stacks are updated. See issue
+    # https://github.com/moby/moby/issues/35048 for details.
+    - name: ensure there is no Docker Swarm stack
+      command: "docker stack rm xsnippet"
+      args:
+        chdir: "/home/xsnippet"
+
+    - name: (re-)create the xsnippet Docker Swarm stack
+      command: "docker stack deploy -c stack.yml xsnippet"
+      args:
+        chdir: "/home/xsnippet"
+      register: result
+      # stack removal may still be in progress and stand in a way - do a few retries if necessary
+      until: result.rc == 0
+      retries: 3
+      delay: 10

--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -1,0 +1,62 @@
+version: "3.3"
+services:
+  db:
+    image: mongo:3
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    volumes:
+      - db_state:/data/db
+    networks:
+      - default
+
+  api:
+    image: {{ xsnippet_api_image }}
+    configs:
+      - source: api_config
+        target: /etc/xsnippet-api.conf
+        mode: 0600
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - db
+    networks:
+      - default
+
+  web:
+    image: nginx:latest
+    configs:
+      - source: web_api_config
+        target: /etc/nginx/conf.d/xsnippet-webserver-api.conf
+        mode: 0600
+      - source: web_spa_config
+        target: /etc/nginx/conf.d/xsnippet-webserver-spa.conf
+        mode: 0600
+    volumes:
+      - /home/xsnippet/xsnippet-web:/www/data:ro
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - api
+    ports:
+      - "80:80"
+    networks:
+      - default
+networks:
+  default:
+
+volumes:
+  db_state:
+
+configs:
+  api_config:
+    file: ./xsnippet-api.conf
+  web_api_config:
+    file: ./xsnippet-webserver-api.conf
+  web_spa_config:
+    file: ./xsnippet-webserver-spa.conf


### PR DESCRIPTION
A simple playbook that allows to deploy both xsnippet-api and
xsnippet-web on the same host behind a shared webserver. See
README.md for details.