### PR TITLE
Enable gzip compression for both API and SPA

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
@@ -7,6 +7,14 @@ server {
 
     server_name {{ xsnippet_api_server_name }};
 
+    # for large list of snippets it may be useful to turn on the gzip compression. At the same time
+    # it's probably not worth it for files smaller than 1kb. Compression ratio of 5 seems to be a
+    # good balance between output size and CPU load.
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types application/json application/javascript;
+    gzip_min_length 1024;
+
     location / {
         add_header 'Access-Control-Allow-Origin' '*';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';

--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -5,6 +5,14 @@ server {
 
     root /www/data;
 
+    # web assets can be pretty large (>= 0.5 mb), so compress them before sending over the wire.
+    # At the same time, it's probably not worth it for files smaller than 1kb. Compression ratio
+    # of 5 seems to be a good balance between output size and CPU load.
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript image/svg+xml;
+    gzip_min_length 1024;
+
     location / {
         error_page 404 =200 /index.html;
 


### PR DESCRIPTION
This is important for serving the SPA assets, as they can be pretty
large (>= 0.5 mb), but may also be useful for retrieving list of
snippets from the API as well.

Compression ratio and minimum size values are chosen, so that we try
to find a good balance between the length of the content sent over
the wire and the CPU load.