### PR TITLE
xsnippet-api: reorder configured syntaxes

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-api.conf.j2
@@ -37,23 +37,39 @@ connection = mongodb://db:27017/xsnippet
 ;
 
 syntaxes =
+    Plain Text
+    C
+    C#
+    C++
+    Go
+    Java
+    PHP
+    Perl
+    Python
+    Ruby
+    Rust
+    CSS
+    HTML
+    JavaScript
+    Objective-C
+    Swift
+    Clojure
+    Common Lisp
+    F#
+    Haskell
+    Scala
+    Scheme
     APL
     ASN.1
     ASP.NET
     Asterisk
     Brainfuck
-    C
-    C#
-    C++
     CMake
     CQL
-    CSS
-    Clojure
     ClojureScript
     Closure Stylesheets (GSS)
     Cobol
     CoffeeScript
-    Common Lisp
     Crystal
     Cypher
     Cython
@@ -71,7 +87,6 @@ syntaxes =
     Embedded Ruby
     Erlang
     Esper
-    F#
     FCL
     Factor
     Forth
@@ -79,22 +94,17 @@ syntaxes =
     Gas
     Gherkin
     GitHub Flavored Markdown
-    Go
     Groovy
     HAML
-    HTML
     HTTP
     HXML
-    Haskell
     Haskell (Literate)
     Haxe
     IDL
     JSON
     JSON-LD
     JSX
-    Java
     Java Server Pages
-    JavaScript
     Jinja2
     Julia
     Kotlin
@@ -113,37 +123,28 @@ syntaxes =
     NTriples
     Nginx
     OCaml
-    Objective-C
     Octave
     Oz
     PEG.js
     PGP
-    PHP
     PLSQL
     Pascal
-    Perl
     Pig
-    Plain Text
     PowerShell
     Properties files
     ProtoBuf
     Pug
     Puppet
-    Python
     Q
     R
     RPM Changes
     RPM Spec
-    Ruby
-    Rust
     SAS
     SCSS
     SPARQL
     SQL
     SQLite
     Sass
-    Scala
-    Scheme
     Shell
     Sieve
     Slim
@@ -154,7 +155,6 @@ syntaxes =
     Spreadsheet
     Squirrel
     Stylus
-    Swift
     SystemVerilog
     TOML
     TTCN


### PR DESCRIPTION
Reoder the list of configured syntaxes to put the most popular choices
on top. In the future, we might want to sort this directly in the API
based on the actual data from the db of snippets.