### PR TITLE
Deploy xsnippet-web-backend alongside xsnippet-web

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -1,3 +1,7 @@
+upstream xsnippet_web_backend {
+    server web_backend:5000;
+}
+
 server {
     listen 80;
 
@@ -12,6 +16,10 @@ server {
     gzip_comp_level 5;
     gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript image/svg+xml;
     gzip_min_length 1024;
+
+    location ~ ^/backend/(.*)$ {
+        proxy_pass http://xsnippet_web_backend/$1;
+    }
 
     location / {
         error_page 404 =200 /index.html;

--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -56,6 +56,7 @@
     # versions of API and SPA to be used
     xsnippet_api_image: xsnippet/xsnippet-api:68b0b7c
     xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/alpha-6/xsnippet_web-alpha-6.tar.gz
+    xsnippet_web_backend_image: xsnippetci/xsnippet-web-backend:latest
   become: true
   become_user: xsnippet
   tasks:

--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -26,6 +26,19 @@ services:
     networks:
       - default
 
+  web_backend:
+    image: {{ xsnippet_web_backend_image }}
+    environment:
+      - XSNIPPET_API_URL=http://{{ xsnippet_api_server_name }}
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      - api
+    networks:
+      - default
+
   web:
     image: nginx:latest
     configs:


### PR DESCRIPTION
xsnippet-web-backend is a web-service, that is meant to be deployed
alongside the xsnippet-web SPA and helps to implement the features,
which can't be implemented purely on the client side (e.g. "raw"
content of the snippets served as plain text over HTTP or "embed"
 mode, etc).