### PR TITLE
xsnippet-web: "publish" the exposed port to the host

### DIFF
--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -43,8 +43,13 @@ services:
         condition: on-failure
     depends_on:
       - api
+    # "publish" the exposed port to the host effectively configuring a DNAT iptables rule. This
+    # is useful for us, becase we get real remote IPs in nginx logs instead of Docker Swarm VIP
     ports:
-      - "80:80"
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
     networks:
       - default
 networks:


### PR DESCRIPTION
"Publish" the exposed port to the host effectively configuring a DNAT
iptables rule. This is useful for us, becase we get real remote IPs
in nginx logs instead of Docker Swarm VIP one.

https://github.com/moby/moby/issues/25526
https://docs.docker.com/engine/swarm/services/#publish-a-services-ports-directly-on-the-swarm-node

Closes #9