### PR TITLE
Configure API and web-backend to use correct access log format

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-api.conf.j2
@@ -15,6 +15,22 @@ host = 0.0.0.0
 port = 8000
 
 
+; ACCESS LOG FORMAT
+;
+; Note, that you have to use double % signs for escaping to work.
+;
+; %t  - datetime of the request
+; %a  - remote address
+; %r  - request status line
+; %s  - response status code
+; %b  - response size (bytes)
+; %Tf - request time (seconds)
+;
+; nginx will set X-Real-IP header value to be equal to remote address
+;
+access_log_format = %%t %%{X-Real-IP}i "%%r" %%s %%b %%{User-Agent}i" %%Tf
+
+
 [database]
 
 ; DATABASE CONNECTION URI

--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -30,6 +30,7 @@ services:
     image: {{ xsnippet_web_backend_image }}
     environment:
       - XSNIPPET_API_URL=http://{{ xsnippet_api_server_name }}
+      - ACCESS_LOG_FORMAT='%t %{X-Real-IP}i "%r" %s %b %{User-Agent}i" %Tf'
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
Make sure we capture the correct remote addr when services are deployed
behind a reverse proxy.

Closes #59