### PR TITLE
Add support for HTTPS in webserver config

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-api.conf.j2
@@ -2,8 +2,29 @@ upstream xsnippet_api {
     server api:8000;
 }
 
+{% if xsnippet_api_https and xsnippet_api_https_redirect %}
+# redirect all HTTP requests to HTTPS
 server {
     listen 80;
+    server_name {{ xsnippet_api_server_name }};
+
+    # use a temporary redirect in case we want to tweak things (otherwise browsers
+    # would cache the results of a permanent redirect)
+    return 307 https://$host$request_uri;
+}
+{% endif %}
+
+server {
+    {% if not (xsnippet_api_https_redirect and xsnippet_api_https) %}
+    # if redirects to HTTPS are not enforced, serve the content over HTTP as well
+    listen 80;
+    {% endif %}
+
+    {% if xsnippet_api_https %}
+    listen 443 ssl;
+    ssl_certificate     /etc/nginx/xsnippet_api_ssl.cert;
+    ssl_certificate_key /etc/nginx/xsnippet_api_ssl.key;
+    {% endif %}
 
     server_name {{ xsnippet_api_server_name }};
 

--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -2,8 +2,29 @@ upstream xsnippet_web_backend {
     server web_backend:5000;
 }
 
+{% if xsnippet_spa_https and xsnippet_spa_https_redirect %}
+# redirect all HTTP requests to HTTPS
 server {
     listen 80;
+    server_name {{ xsnippet_spa_server_name }};
+
+    # use a temporary redirect in case we want to tweak things (otherwise browsers
+    # would cache the results of a permanent redirect)
+    return 307 https://$host$request_uri;
+}
+{% endif %}
+
+server {
+    {% if not (xsnippet_spa_https_redirect and xsnippet_spa_https) %}
+    # if redirects to HTTPS are not enforced, serve the content over HTTP as well
+    listen 80;
+    {% endif %}
+
+    {% if xsnippet_spa_https %}
+    listen 443 ssl;
+    ssl_certificate     /etc/nginx/xsnippet_spa_ssl.cert;
+    ssl_certificate_key /etc/nginx/xsnippet_spa_ssl.key;
+    {% endif %}
 
     server_name {{ xsnippet_spa_server_name }};
 

--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -57,9 +57,40 @@
     xsnippet_api_image: xsnippet/xsnippet-api:b70162b
     xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/alpha-8/xsnippet_web-alpha-8.tar.gz
     xsnippet_web_backend_image: xsnippetci/xsnippet-web-backend:latest
+    # paths to SSL certifactes on the target machine
+    xsnippet_api_https_redirect: false  # do not force HTTPS redirect for now to allow for local development
+    xsnippet_api_ssl_cert: /home/xsnippet/xsnippet_api_ssl.cert
+    xsnippet_api_ssl_key: /home/xsnippet/xsnippet_api_ssl.key
+    xsnippet_spa_https_redirect: true
+    xsnippet_spa_ssl_cert: /home/xsnippet/xsnippet_spa_ssl.cert
+    xsnippet_spa_ssl_key: /home/xsnippet/xsnippet_spa_ssl.key
   become: true
   become_user: xsnippet
   tasks:
+    - stat:
+        path: "{{ xsnippet_api_ssl_cert }}"
+      register: xsnippet_api_ssl_cert_file
+
+    - stat:
+        path: "{{ xsnippet_api_ssl_key }}"
+      register: xsnippet_api_ssl_key_file
+
+    - name: serve xsnippet-api over HTTPS, if a certifacte/key pair has been provided
+      set_fact:
+        xsnippet_api_https: "{{ xsnippet_api_ssl_cert_file.stat.exists and xsnippet_api_ssl_key_file.stat.exists }}"
+
+    - stat:
+        path: "{{ xsnippet_spa_ssl_cert }}"
+      register: xsnippet_spa_ssl_cert_file
+
+    - stat:
+        path: "{{ xsnippet_spa_ssl_key }}"
+      register: xsnippet_spa_ssl_key_file
+
+    - name: serve xsnippet-web (and xsnippet-web-backend) over HTTPS, if a certifacte/key pair has been provided
+      set_fact:
+        xsnippet_spa_https: "{{ xsnippet_spa_ssl_cert_file.stat.exists and xsnippet_spa_ssl_key_file.stat.exists }}"
+
     - file:
         path: "/home/xsnippet/xsnippet-web"
         state: directory

--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -51,6 +51,14 @@ services:
         mode: 0600
     volumes:
       - /home/xsnippet/xsnippet-web:/www/data:ro
+{% if xsnippet_api_https %}
+      - {{ xsnippet_api_ssl_cert }}:/etc/nginx/xsnippet_api_ssl.cert:ro
+      - {{ xsnippet_api_ssl_key }}:/etc/nginx/xsnippet_api_ssl.key:ro
+{% endif %}
+{% if xsnippet_spa_https %}
+      - {{ xsnippet_spa_ssl_cert }}:/etc/nginx/xsnippet_spa_ssl.cert:ro
+      - {{ xsnippet_spa_ssl_key }}:/etc/nginx/xsnippet_spa_ssl.key:ro
+{% endif %}
     deploy:
       replicas: 1
       restart_policy:
@@ -64,6 +72,12 @@ services:
         published: 80
         protocol: tcp
         mode: host
+{% if xsnippet_api_https or xsnippet_spa_https %}
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+{% endif %}
     networks:
       - default
 networks:


### PR DESCRIPTION
Allow for configuring nginx to listen for HTTPS connections, if SSL
certificates are provided. The certificates and corresponding private
keys must be installed on the target host manually before executing
this playbook. Paths to these files are specified by the means of
the following variables:

  xsnippet_api_ssl_cert
  xsnippet_api_ssl_key
  xsnippet_spa_ssl_cert
  xsnippet_spa_ssl_key

It's also possible to configure a `307 Temporary Redirect` from HTTP
to HTTPS by the means of the following variables:

  xsnippet_api_https_redirect
  xsnippet_spa_https_redirect

Note, that we use a temporary redirect instead of a permanent one,
so that web browsers do not cache it and we can tweak things, if
needed, without having to tell people to clear their caches.

API does not force a redirect to HTTPS for now, as we want to allow
for local development of xsnippet-web.

Closes #13