### PR TITLE
web-backend: ensure existing links to "raw" snippets work

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -38,8 +38,8 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/javascript application/javascript image/svg+xml;
     gzip_min_length 1024;
 
-    location ~ ^/backend/(.*)$ {
-        proxy_pass http://xsnippet_web_backend/$1;
+    location ~ ^/(\d+)/raw/?$ {
+        proxy_pass http://xsnippet_web_backend/snippets/$1/raw;
     }
 
     location / {


### PR DESCRIPTION
Add a new location to nginx configuration, so that we continue to
serve existing links to "raw" versions of snippets from xsnippet.org,
e.g. https://beta.xsnippet.org/122/raw/