### PR TITLE
Send all Docker container logs to journald

### DIFF
--- a/ansible/all-in-one/configs/docker.conf.j2
+++ b/ansible/all-in-one/configs/docker.conf.j2
@@ -1,0 +1,3 @@
+{
+  "log-driver": "journald"
+}

--- a/ansible/all-in-one/configs/xsnippet-api.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-api.conf.j2
@@ -28,7 +28,7 @@ port = 8000
 ;
 ; nginx will set X-Real-IP header value to be equal to remote address
 ;
-access_log_format = %%t %%{X-Real-IP}i "%%r" %%s %%b %%{User-Agent}i" %%Tf
+access_log_format = %%{X-Real-IP}i "%%r" %%s %%b %%{User-Agent}i" %%Tf
 
 
 [database]

--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -36,6 +36,21 @@
     - name: install the latest Docker
       apt: name=docker-ce state=latest
 
+    - name: configure Docker to send container logs to journald
+      template:
+        src: configs/docker.conf.j2
+        dest: "/etc/docker/daemon.json"
+        mode: 0644
+        owner: root
+        group: root
+      register: newdockerconf
+
+    - name: restart Docker (if needed)
+      service:
+        name: docker
+        state: restarted
+      when: newdockerconf.changed
+
     - name: initialize Docker Swarm
       shell: "docker swarm init --advertise-addr 127.0.0.1 || docker stack ls"
       register: init_result

--- a/ansible/all-in-one/docker/stack.yml.j2
+++ b/ansible/all-in-one/docker/stack.yml.j2
@@ -8,6 +8,9 @@ services:
         condition: on-failure
     volumes:
       - db_state:/data/db
+    logging:
+      options:
+        tag: xsnippet_db
     networks:
       - default
 
@@ -23,6 +26,9 @@ services:
         condition: on-failure
     depends_on:
       - db
+    logging:
+      options:
+        tag: xsnippet_api
     networks:
       - default
 
@@ -30,13 +36,16 @@ services:
     image: {{ xsnippet_web_backend_image }}
     environment:
       - XSNIPPET_API_URL=http://{{ xsnippet_api_server_name }}
-      - ACCESS_LOG_FORMAT='%t %{X-Real-IP}i "%r" %s %b %{User-Agent}i" %Tf'
+      - ACCESS_LOG_FORMAT='%{X-Real-IP}i "%r" %s %b %{User-Agent}i" %Tf'
     deploy:
       replicas: 1
       restart_policy:
         condition: on-failure
     depends_on:
       - api
+    logging:
+      options:
+        tag: xsnippet_web_backend
     networks:
       - default
 
@@ -49,6 +58,9 @@ services:
       - source: web_spa_config
         target: /etc/nginx/conf.d/xsnippet-webserver-spa.conf
         mode: 0600
+    logging:
+      options:
+        tag: xsnippet_web
     volumes:
       - /home/xsnippet/xsnippet-web:/www/data:ro
 {% if xsnippet_api_https %}


### PR DESCRIPTION
Make sure we have all the logs stored in the same place. This way
they are easier to manage, e.g. if we want to forward them somewhere
or simply configure periodic backups.

Update access log formats of xsnippet-api and xsnippet-web-backend,
so that we do not have duplicate timestamp values in logs (as
journald will add its own timestamp to every log entry).

One can get the logs by the means of journalctl, e.g.:

    $ journalctl -f CONTAINER_TAG=xsnippet_api

Note, that we assign a unique tag for each service in a Docker Swarm
stack, as names/ids of containers change on each update and we can't
rely on them.