### PR TITLE
Use xsnippetci/xsnippet-api docker image

### DIFF
--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -69,7 +69,7 @@
     xsnippet_api_server_name: api.xsnippet.org
     xsnippet_spa_server_name: xsnippet.org
     # versions of API and SPA to be used
-    xsnippet_api_image: xsnippet/xsnippet-api:b70162b
+    xsnippet_api_image: xsnippetci/xsnippet-api:latest
     xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/v1.0.0/xsnippet_web-v1.0.0.tar.gz
     xsnippet_web_backend_image: xsnippetci/xsnippet-web-backend:latest
     # paths to SSL certifactes on the target machine


### PR DESCRIPTION
We used to use xsnippet/xsnippet-api docker image that's created by
Docker automatically. However, few months ago we moved away to
xsnippetci/xsnippet-api docker image that's pushed by CI user on
success. Apparently, there's a huge difference between these two images,
as the later is always new while the former is 3 months long.

One of the issues of using xsnippet/xsnippet-api is that this version
does not support changesets on database schema, and create snippets in
database without changesets attribute.