### PR TITLE
Use proper Docker images

### DIFF
--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -69,9 +69,9 @@
     xsnippet_api_server_name: api.xsnippet.org
     xsnippet_spa_server_name: xsnippet.org
     # versions of API and SPA to be used
-    xsnippet_api_image: xsnippet/xsnippet-api:b70162b
+    xsnippet_api_image: xsnippet/xsnippet-api:v1.0.0
     xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/v1.0.0/xsnippet_web-v1.0.0.tar.gz
-    xsnippet_web_backend_image: xsnippetci/xsnippet-web-backend:latest
+    xsnippet_web_backend_image: xsnippet/xsnippet-web-backend:v1.0.0
     # paths to SSL certifactes on the target machine
     xsnippet_api_https_redirect: false  # do not force HTTPS redirect for now to allow for local development
     xsnippet_api_ssl_cert: /home/xsnippet/xsnippet_api_ssl.cert


### PR DESCRIPTION
Previously we used

 * 'latest' docker image for xsnippet-web-backend which is not cool
   because will not produce reproducible application deployments.

 * xsnippetci/xsnippet-web-backend image which is obsolete as we decided
   to stick with more natural xsnippet/xsnippet-web-backend.

 * pretty old container of xsnippet-api which is at least 3 month old.

That's not the way we want to keep the things, so let's change it.