### PR TITLE
Workaround Ansible 2.5 issue with unarchive module

### DIFF
--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -110,9 +110,21 @@
         path: "/home/xsnippet/xsnippet-web"
         state: directory
 
+    # Due to the issue [1], we cannot use 'unarchive' module to download and
+    # extract the archive while under 'become_user' mode; there's something
+    # increadibly wrong about tmpdir manipulating. Therefore, we do two-step
+    # action: first, download the archive; second, extract it to the target
+    # directory.
+    #
+    # [1]: https://github.com/ansible/ansible/issues/38672
     - name: prepare xsnippet-web assets
-      unarchive:
-        src: "{{ xsnippet_web_assets }}"
+      get_url:
+        url: "{{ xsnippet_web_assets }}"
+        dest: /tmp/xsnippet-web.tar-gz
+        force: true
+
+    - unarchive:
+        src: /tmp/xsnippet-web.tar-gz
         dest: "/home/xsnippet/xsnippet-web"
         remote_src: yes
 


### PR DESCRIPTION
Due to the issue [1], we cannot use 'unarchive' module to download and
extract the archive while under 'become_user' mode; there's something
increadibly wrong about tmpdir manipulating. Therefore, we do two-step
action: first, download the archive; second, extract it to the target
directory.

[1]: https://github.com/ansible/ansible/issues/38672