### PR TITLE
Deploy the latest versions of xsnippet-api and xsnippet-web

### DIFF
--- a/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/configs/xsnippet-webserver-spa.conf.j2
@@ -42,6 +42,12 @@ server {
         proxy_pass http://xsnippet_web_backend/snippets/$1/raw;
     }
 
+    # return the dynamic config, if it exists; otherwise, return 404, that will be handled by the SPA
+    # (note, that we only need this because we normally convert all 404s to be 200s and return the SPA code below)
+    location /conf.json {
+        try_files /conf.json =404;
+    }
+
     location / {
         error_page 404 =200 /index.html;
 

--- a/ansible/all-in-one/deploy.yaml
+++ b/ansible/all-in-one/deploy.yaml
@@ -69,8 +69,8 @@
     xsnippet_api_server_name: api.xsnippet.org
     xsnippet_spa_server_name: xsnippet.org
     # versions of API and SPA to be used
-    xsnippet_api_image: xsnippet/xsnippet-api:v1.0.0
-    xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/v1.0.0/xsnippet_web-v1.0.0.tar.gz
+    xsnippet_api_image: xsnippet/xsnippet-api:v1.1.0
+    xsnippet_web_assets: https://github.com/xsnippet/xsnippet-web/releases/download/v1.0.1/xsnippet_web-v1.0.1.tar.gz
     xsnippet_web_backend_image: xsnippet/xsnippet-web-backend:v1.0.0
     # paths to SSL certifactes on the target machine
     xsnippet_api_https_redirect: false  # do not force HTTPS redirect for now to allow for local development


### PR DESCRIPTION
Update the nginx config to correctly serve the dynamic config, or
return a 404 not found if the config is not defined.