### PR TITLE
Use Github Workflows instead of Travis CI for testing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ansible:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ansible
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade ansible
+
+      - name: Run the all-in-one playbook
+        run: |
+          ansible-playbook -vv --inventory "xsnippet," --connection=local ansible/all-in-one/deploy.yaml
+
+      - name: Smoke test
+        run: |
+          for i in `seq 180`; do
+            curl http://localhost/v1/syntaxes && exit 0 || sleep 1
+          done
+
+          echo "http://localhost/v1/syntaxes is unavailable after 180s. Giving up."
+          exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: required
-dist: xenial
-language: python
-
-install:
-  - pip install ansible
-
-script:
-  - ansible-playbook -vv --inventory "xsnippet," --connection=local ansible/all-in-one/deploy.yaml


### PR DESCRIPTION
The commit that sets up Github Workflows must go to the default branch. We can submit this, and then branch off version/v4 from master.