### PR TITLE
Add a helper role for mounting an external volume

### DIFF
--- a/ansible/all-in-one/README.md
+++ b/ansible/all-in-one/README.md
@@ -37,11 +37,12 @@ $ ansible-playbook -i path_to_inventory site.yml
 Variables
 =========
 
-| Name                         | Description                                           |
-| ---------------------------- | ----------------------------------------------------- |
-| `xsnippet_api_server_name`   | server name (aka, virtual host) of the backend API    |
-| `xsnippet_spa_server_name`   | server name (aka, virtual host) of the frontent SPA   |
-| `xsnippet_api_image`         | Docker image of xsnippet-api to be used               |
-| `xsnippet_db_image`          | Docker image of xsnippet-db to be used                |
-| `xsnippet_web_image`         | Docker image of xsnippet-web to be used               |
-| `xsnippet_web_assets`        | URL of the SPA tarball release to be used             |
+| Name                          | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `xsnippet_api_server_name`    | server name (aka, virtual host) of the backend API    |
+| `xsnippet_spa_server_name`    | server name (aka, virtual host) of the frontent SPA   |
+| `xsnippet_api_image`          | Docker image of xsnippet-api to be used               |
+| `xsnippet_db_image`           | Docker image of xsnippet-db to be used                |
+| `xsnippet_db_external_volume` | Disk that should be used for storing the DB state     |
+| `xsnippet_web_image`          | Docker image of xsnippet-web to be used               |
+| `xsnippet_web_assets`         | URL of the SPA tarball release to be used             |

--- a/ansible/all-in-one/roles/volume/tasks/main.yml
+++ b/ansible/all-in-one/roles/volume/tasks/main.yml
@@ -1,0 +1,39 @@
+- name: check if the external volume already has a filesystem
+  command: "lsblk --fs --json {{ external_volume }}"
+  register: lsblk
+
+- set_fact:
+    external_volume_has_fs: "{{ (lsblk.stdout | from_json)['blockdevices'][0]['fstype'] is not none }}"
+
+- name: if not, create a new filesystem
+  command: "mkfs.{{ external_volume_fs }} {{ external_volume }}"
+  when: not external_volume_has_fs
+
+- name: create the target directory
+  file:
+    path: "{{ external_volume_mountpoint }}"
+    state: directory
+    owner: "{{ external_volume_owner }}"
+    group: "{{ external_volume_owner }}"
+    mode: "{{ external_volume_mode }}"
+
+- name: create and activate the mountpoint
+  mount:
+    path: "{{ external_volume_mountpoint }}"
+    src: "{{ external_volume }}"
+    fstype: "{{ external_volume_fs }}"
+    opts: "{{ external_volume_mount_options }}"
+    state: mounted
+
+- name: ensure the mounted fs has the correct permissions
+  file:
+    path: "{{ external_volume_mountpoint }}"
+    state: directory
+    owner: "{{ external_volume_owner }}"
+    group: "{{ external_volume_owner }}"
+    mode: "{{ external_volume_mode }}"
+    recurse: true
+  # we need to execute this step only once, as root-less Podman will update
+  # uids/gids on all files the first time xsnippet-db is started, and we don't
+  # want to mess with that
+  when: not external_volume_has_fs

--- a/ansible/all-in-one/roles/volume/vars/main.yml
+++ b/ansible/all-in-one/roles/volume/vars/main.yml
@@ -1,0 +1,13 @@
+# The disk (or partition) to store the xsnippet-db's persistent state on. If not specified, the data will be stored on
+# the root FS partition.
+external_volume:
+# The FS type that the disk (or partition) should be formatted in (mkfs will be called if the target is empty).
+external_volume_fs: ext4
+# The path of where to mount the external volume
+external_volume_mountpoint: /home/xsnippet/data
+# The user who should be the owner of the external volume mountpoint
+external_volume_owner: xsnippet
+# The file access mode for the external volume mountpoint
+external_volume_mode: "0700"
+# Comma-separate list of options used when mounting the external volume
+external_volume_mount_options: "discard,defaults,noatime"

--- a/ansible/all-in-one/roles/xsnippet/tasks/main.yml
+++ b/ansible/all-in-one/roles/xsnippet/tasks/main.yml
@@ -12,6 +12,16 @@
   become: true
   become_user: root
 
+- name: create and mount the external volume for storing xsnippet-db's data (if it is configured)
+  include_role:
+    name: volume
+    apply:
+      become: yes
+      become_user: root
+  vars:
+    external_volume: "{{ xsnippet_db_external_volume }}"
+  when: xsnippet_db_external_volume
+
 - stat:
     path: "{{ xsnippet_api_ssl_cert }}"
   register: xsnippet_api_ssl_cert_file
@@ -36,7 +46,7 @@
     path: "/home/xsnippet/xsnippet-web"
     state: directory
 - file:
-    path: "/home/xsnippet/data"
+    path: "/home/xsnippet/data/db"
     state: directory
 - file:
     path: "/home/xsnippet/nginx-conf.d"
@@ -44,6 +54,7 @@
 - file:
     path: "/home/xsnippet/.config/systemd/user"
     state: directory
+
 
 # Due to the issue [1], we cannot use 'unarchive' module to download and
 # extract the archive while under 'become_user' mode; there's something

--- a/ansible/all-in-one/roles/xsnippet/templates/xsnippet.yml.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/xsnippet.yml.j2
@@ -67,7 +67,7 @@ spec:
   volumes:
     - name: database-state
       hostPath:
-        path: /home/xsnippet/data
+        path: /home/xsnippet/data/db
         type: Directory
     - name: spa-assets
       hostPath:

--- a/ansible/all-in-one/roles/xsnippet/vars/main.yml
+++ b/ansible/all-in-one/roles/xsnippet/vars/main.yml
@@ -9,6 +9,7 @@ xsnippet_db_name: xsnippet
 xsnippet_db_user: xsnippet
 xsnippet_db_password: xsnippet
 xsnippet_db_port: 5432
+xsnippet_db_external_volume: ""
 
 # application configuration
 xsnippet_syntaxes: "{{ lookup('file', 'syntaxes.txt').split('\n') }}"


### PR DESCRIPTION
In production, we want to use an external volume for storing xsnippet-db's persistent state. Add a helper role that allows us to do that when `xsnippet_db_external_volume` is configured.