### PR TITLE
Add SSL/TLS generation configuration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run the all-in-one playbook
         run: |
-          ansible-playbook --extra-vars '{"require_cgroupsv2": false, "xsnippet_api_https_redirect": false}' -vv --inventory "xsnippet," --connection=local ansible/all-in-one/site.yml
+          ansible-playbook --extra-vars '{"require_cgroupsv2": false, "xsnippet_api_https_enabled": false, "xsnippet_spa_https_enabled": false}' -vv --inventory "xsnippet," --connection=local ansible/all-in-one/site.yml
 
       - name: Smoke test
         run: |

--- a/ansible/all-in-one/README.md
+++ b/ansible/all-in-one/README.md
@@ -46,3 +46,6 @@ Variables
 | `xsnippet_db_external_volume` | Disk that should be used for storing the DB state     |
 | `xsnippet_web_image`          | Docker image of xsnippet-web to be used               |
 | `xsnippet_web_assets`         | URL of the SPA tarball release to be used             |
+| `xsnippet_api_https_enabled`  | secure backend API with TLS (via let's encrypt)       |
+| `xsnippet_spa_https_enabled`  | secure frontend SPA with TLS (via let's encrypt)      |
+| `digitalocean_token`          | digitalocean token used by let's encrypt challenge    |

--- a/ansible/all-in-one/roles/certbot/tasks/main.yml
+++ b/ansible/all-in-one/roles/certbot/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: update apt cache (if needed)
+  apt: update_cache=yes cache_valid_time=3600
+
+- name: install the certbot package
+  apt:
+    name:
+      - certbot
+      - python3-certbot-dns-digitalocean
+    state: latest

--- a/ansible/all-in-one/roles/sockets/tasks/main.yml
+++ b/ansible/all-in-one/roles/sockets/tasks/main.yml
@@ -10,7 +10,7 @@
 - copy:
     src: "{{ item }}"
     dest: /etc/systemd/system/
-  when: xsnippet_api_https or xsnippet_spa_https
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled
   loop:
     - https.socket
     - https.service
@@ -31,4 +31,4 @@
     name: "https.socket"
     enabled: yes
     state: started
-  when: xsnippet_api_https or xsnippet_spa_https
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled

--- a/ansible/all-in-one/roles/xsnippet/tasks/main.yml
+++ b/ansible/all-in-one/roles/xsnippet/tasks/main.yml
@@ -22,26 +22,6 @@
     external_volume: "{{ xsnippet_db_external_volume }}"
   when: xsnippet_db_external_volume
 
-- stat:
-    path: "{{ xsnippet_api_ssl_cert }}"
-  register: xsnippet_api_ssl_cert_file
-- stat:
-    path: "{{ xsnippet_api_ssl_key }}"
-  register: xsnippet_api_ssl_key_file
-- name: serve xsnippet-api over HTTPS if a certificate/key pair has been provided
-  set_fact:
-    xsnippet_api_https: "{{ xsnippet_api_ssl_cert_file.stat.exists and xsnippet_api_ssl_key_file.stat.exists }}"
-
-- stat:
-    path: "{{ xsnippet_spa_ssl_cert }}"
-  register: xsnippet_spa_ssl_cert_file
-- stat:
-    path: "{{ xsnippet_spa_ssl_key }}"
-  register: xsnippet_spa_ssl_key_file
-- name: serve xsnippet-web over HTTPS, if a certificate/key pair has been provided
-  set_fact:
-    xsnippet_spa_https: "{{ xsnippet_spa_ssl_cert_file.stat.exists and xsnippet_spa_ssl_key_file.stat.exists }}"
-
 - file:
     path: "/home/xsnippet/xsnippet-web"
     state: directory
@@ -54,7 +34,85 @@
 - file:
     path: "/home/xsnippet/.config/systemd/user"
     state: directory
+- file:
+    path: "/home/xsnippet/.config/letsencrypt"
+    state: directory
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled
 
+- name: prepare the certbot config
+  template:
+    src:  certbot.ini.j2
+    dest: "/home/xsnippet/.config/letsencrypt/cli.ini"
+    mode: 0600
+    owner: xsnippet
+    group: xsnippet
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled
+
+- name: prepare the certbot-dns-digitalocean config
+  template:
+    src:  dns-digitalocean-credentials.ini.j2
+    dest: "/home/xsnippet/.config/letsencrypt/dns-digitalocean-credentials.ini"
+    mode: 0600
+    owner: xsnippet
+    group: xsnippet
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled
+
+- name: generate ssl for {{ xsnippet_api_server_name }}
+  command: certbot certonly --domains {{ xsnippet_api_server_name }}
+  args:
+    creates: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_api_server_name }}/*.pem"
+  when: xsnippet_api_https_enabled
+
+- name: generate ssl for {{ xsnippet_spa_server_name }}
+  command: certbot certonly --domains {{ xsnippet_spa_server_name }}
+  args:
+    creates: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_spa_server_name }}/*.pem"
+  when: xsnippet_spa_https_enabled
+
+- stat:
+    path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_api_server_name }}/fullchain.pem"
+  register: xsnippet_api_ssl_cert_file
+  when: xsnippet_api_https_enabled
+
+- stat:
+    path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_api_server_name }}/privkey.pem"
+  register: xsnippet_api_ssl_key_file
+  when: xsnippet_api_https_enabled
+
+- stat:
+    path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_spa_server_name }}/fullchain.pem"
+  register: xsnippet_spa_ssl_cert_file
+  when: xsnippet_spa_https_enabled
+
+- stat:
+    path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_spa_server_name }}/privkey.pem"
+  register: xsnippet_spa_ssl_key_file
+  when: xsnippet_spa_https_enabled
+
+# Since CERT/PKEY-s we deal with are symlinks, we have to resolve them into
+# target paths before trying to mount them into containers.
+- set_fact:
+    xsnippet_api_ssl_cert_file: "{{ xsnippet_api_ssl_cert_file.stat.lnk_source }}"
+    xsnippet_api_ssl_key_file: "{{ xsnippet_api_ssl_key_file.stat.lnk_source }}"
+    xsnippet_spa_ssl_cert_file: "{{ xsnippet_spa_ssl_cert_file.stat.lnk_source }}"
+    xsnippet_spa_ssl_key_file: "{{ xsnippet_spa_ssl_key_file.stat.lnk_source }}"
+  when: xsnippet_api_https_enabled or xsnippet_spa_https_enabled
+
+- name: prepare the certbot systemd units
+  copy:
+    src: "{{ item }}"
+    dest: "/home/xsnippet/.config/systemd/user/"
+    remote_src: yes
+  loop:
+    - /lib/systemd/system/certbot.service
+    - /lib/systemd/system/certbot.timer
+
+- name: enable the certbot renew periodic timer
+  systemd:
+    name: certbot.timer
+    enabled: yes
+    state: restarted
+    scope: user
 
 # Due to the issue [1], we cannot use 'unarchive' module to download and
 # extract the archive while under 'become_user' mode; there's something
@@ -148,3 +206,56 @@
     enabled: yes
     state: restarted
     scope: user
+
+- name: proxy HTTP and HTTPS from host to containers
+  include_role:
+    name: sockets
+    apply:
+      become: yes
+      become_user: root
+
+- name: systemd unit - restart {{ restart_service_name }} on SSL renewal
+  vars:
+    restart_service_name: container-xsnippet-web.service
+    watch_path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_api_server_name }}"
+  template:
+    src: "{{ item }}"
+    dest: "/home/xsnippet/.config/systemd/user/xsnippet-api-{{ item | splitext | first }}"
+    mode: 0600
+    owner: xsnippet
+    group: xsnippet
+  loop:
+    - cert-watcher.service.j2
+    - cert-watcher.path.j2
+  when: xsnippet_api_https_enabled
+
+- name: systemd unit - restart {{ restart_service_name }} on SSL renewal
+  vars:
+    restart_service_name: container-xsnippet-web.service
+    watch_path: "/home/xsnippet/.config/letsencrypt/live/{{ xsnippet_spa_server_name }}"
+  template:
+    src: "{{ item }}"
+    dest: "/home/xsnippet/.config/systemd/user/xsnippet-web-{{ item | splitext | first }}"
+    mode: 0600
+    owner: xsnippet
+    group: xsnippet
+  loop:
+    - cert-watcher.service.j2
+    - cert-watcher.path.j2
+  when: xsnippet_spa_https_enabled
+
+- name: watch for SSL renewal and restart xsnippet-api if detected
+  systemd:
+    name: xsnippet-api-cert-watcher.path
+    enabled: yes
+    state: restarted
+    scope: user
+  when: xsnippet_api_https_enabled
+
+- name: watch for SSL renewal and restart xsnippet-web if detected
+  systemd:
+    name: xsnippet-web-cert-watcher.path
+    enabled: yes
+    state: restarted
+    scope: user
+  when: xsnippet_spa_https_enabled

--- a/ansible/all-in-one/roles/xsnippet/templates/cert-watcher.path.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/cert-watcher.path.j2
@@ -1,0 +1,5 @@
+[Path]
+PathModified={{ watch_path }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/all-in-one/roles/xsnippet/templates/cert-watcher.service.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/cert-watcher.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Restart {{ restart_service_name }}
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl --user restart {{ restart_service_name }}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/all-in-one/roles/xsnippet/templates/certbot.ini.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/certbot.ini.j2
@@ -1,0 +1,11 @@
+email = dev@xsnippet.org
+quiet = true
+agree-tos = true
+max-log-backups = 0
+
+dns-digitalocean = true
+dns-digitalocean-credentials = /home/xsnippet/.config/letsencrypt/dns-digitalocean-credentials.ini
+
+config-dir = /home/xsnippet/.config/letsencrypt
+work-dir = /home/xsnippet/.local/share/letsencrypt
+logs-dir = /home/xsnippet/.local/share/letsencrypt_logs

--- a/ansible/all-in-one/roles/xsnippet/templates/dns-digitalocean-credentials.ini.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/dns-digitalocean-credentials.ini.j2
@@ -1,0 +1,1 @@
+dns_digitalocean_token = {{ digitalocean_token }}

--- a/ansible/all-in-one/roles/xsnippet/templates/xsnippet-webserver-api.conf.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/xsnippet-webserver-api.conf.j2
@@ -2,7 +2,7 @@ upstream xsnippet_api {
     server localhost:8000;
 }
 
-{% if xsnippet_api_https and xsnippet_api_https_redirect %}
+{% if xsnippet_api_https_enabled and xsnippet_api_https_redirect %}
 # redirect all HTTP requests to HTTPS
 server {
     listen 80;
@@ -15,12 +15,12 @@ server {
 {% endif %}
 
 server {
-    {% if not (xsnippet_api_https_redirect and xsnippet_api_https) %}
+    {% if not (xsnippet_api_https_redirect and xsnippet_api_https_enabled) %}
     # if redirects to HTTPS are not enforced, serve the content over HTTP as well
     listen 80;
     {% endif %}
 
-    {% if xsnippet_api_https %}
+    {% if xsnippet_api_https_enabled %}
     listen 443 ssl;
     ssl_certificate     /etc/nginx/xsnippet_api_ssl.cert;
     ssl_certificate_key /etc/nginx/xsnippet_api_ssl.key;

--- a/ansible/all-in-one/roles/xsnippet/templates/xsnippet-webserver-spa.conf.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/xsnippet-webserver-spa.conf.j2
@@ -1,6 +1,6 @@
 js_import conf.d/xsnippet_api.js;
 
-{% if xsnippet_spa_https and xsnippet_spa_https_redirect %}
+{% if xsnippet_spa_https_enabled and xsnippet_spa_https_redirect %}
 # redirect all HTTP requests to HTTPS
 server {
     listen 80;
@@ -13,12 +13,12 @@ server {
 {% endif %}
 
 server {
-    {% if not (xsnippet_spa_https_redirect and xsnippet_spa_https) %}
+    {% if not (xsnippet_spa_https_redirect and xsnippet_spa_https_enabled) %}
     # if redirects to HTTPS are not enforced, serve the content over HTTP as well
     listen 80;
     {% endif %}
 
-    {% if xsnippet_spa_https %}
+    {% if xsnippet_spa_https_enabled %}
     listen 443 ssl;
     ssl_certificate     /etc/nginx/xsnippet_spa_ssl.cert;
     ssl_certificate_key /etc/nginx/xsnippet_spa_ssl.key;

--- a/ansible/all-in-one/roles/xsnippet/templates/xsnippet.yml.j2
+++ b/ansible/all-in-one/roles/xsnippet/templates/xsnippet.yml.j2
@@ -39,7 +39,7 @@ spec:
         - mountPath: /etc/nginx/nginx.conf
           name: nginx-conf
           readOnly: true
-{% if xsnippet_api_https %}
+{% if xsnippet_api_https_enabled %}
         - mountPath: /etc/nginx/xsnippet_api_ssl.cert
           name: api-ssl-cert
           readOnly: true
@@ -47,7 +47,7 @@ spec:
           name: api-ssl-key
           readOnly: true
 {% endif %}
-{% if xsnippet_spa_https %}
+{% if xsnippet_spa_https_enabled %}
         - mountPath: /etc/nginx/xsnippet_spa_ssl.cert
           name: spa-ssl-cert
           readOnly: true
@@ -59,7 +59,7 @@ spec:
         - containerPort: 80
           hostPort: {{ xsnippet_proxy_http_port|default('8080') }}
           protocol: TCP
-{% if xsnippet_api_https or xsnippet_spa_https %}
+{% if xsnippet_api_https_enabled or xsnippet_spa_https_enabled %}
         - containerPort: 443
           hostPort: {{ xsnippet_proxy_https_port|default('8443') }}
           protocol: TCP
@@ -81,7 +81,7 @@ spec:
       hostPath:
         path: /home/xsnippet/nginx.conf
         type: File
-{% if xsnippet_api_https %}
+{% if xsnippet_api_https_enabled %}
     - name: api-ssl-cert
       hostPath:
         path: "{{ xsnippet_api_ssl_cert_file }}"
@@ -91,7 +91,7 @@ spec:
         path: "{{ xsnippet_api_ssl_key_file }}"
         type: File
 {% endif %}
-{% if xsnippet_spa_https %}
+{% if xsnippet_spa_https_enabled %}
     - name: spa-ssl-cert
       hostPath:
         path: "{{ xsnippet_spa_ssl_cert_file }}"

--- a/ansible/all-in-one/roles/xsnippet/vars/main.yml
+++ b/ansible/all-in-one/roles/xsnippet/vars/main.yml
@@ -22,8 +22,9 @@ access_log_format: '%{X-Real-IP}i "%r" %s %b %{User-Agent}i" %Tf'
 
 # SSL/TLS configuration
 xsnippet_api_https_redirect: true
-xsnippet_api_ssl_cert: /home/xsnippet/xsnippet_api_ssl.cert
-xsnippet_api_ssl_key: /home/xsnippet/xsnippet_api_ssl.key
+xsnippet_api_https_enabled: true
 xsnippet_spa_https_redirect: true
-xsnippet_spa_ssl_cert: /home/xsnippet/xsnippet_spa_ssl.cert
-xsnippet_spa_ssl_key: /home/xsnippet/xsnippet_spa_ssl.key
+xsnippet_spa_https_enabled: true
+
+# Digitalocean token that can be used by certbot to generate SSL.
+digitalocean_token: "{{ lookup('env', 'DIGITALOCEAN_TOKEN') | default('', True) }}"

--- a/ansible/all-in-one/site.yml
+++ b/ansible/all-in-one/site.yml
@@ -2,6 +2,6 @@
 - hosts: xsnippet
   roles:
     - { role: firewall, become: yes }
+    - { role: certbot, become: yes }
     - { role: podman, become: yes }
     - { role: xsnippet, become: yes, become_user: xsnippet }
-    - { role: sockets, become: yes }


### PR DESCRIPTION
The patch uses Let's Encrypt together with DigitalOcean provider to
issue SSL/TLS certificates for our needs. It also setups a systemd timer
to renew certificates periodically.