### PR TITLE
Add a GH Action workflow for continuous delivery

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,59 @@
+name: cd
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: xsnippet.org
+      url: https://xsnippet.org
+    concurrency: xsnippet.org
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Ansible
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade ansible
+
+      - name: Setup a deployment SSH key
+        env:
+          DEPLOYMENT_SSH_KEY_PATH: ${{ runner.temp }}/id_ed25519
+        run: |
+          echo "${{ secrets.DEPLOYMENT_SSH_KEY }}" > ${DEPLOYMENT_SSH_KEY_PATH}
+          chmod 0600 ${DEPLOYMENT_SSH_KEY_PATH}
+          echo "DEPLOYMENT_SSH_KEY_PATH=${DEPLOYMENT_SSH_KEY_PATH}" >> $GITHUB_ENV
+
+      - name: Deploy to production
+        env:
+          ANSIBLE_SSH_HOST: xsnippet.org
+          ANSIBLE_SSH_USER: root
+          ANSIBLE_INVENTORY_PATH: ${{ runner.temp }}/inventory.ini
+          ANSIBLE_PLAYBOOK_PATH: ansible/all-in-one/site.yml
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+          VOLUME_ID: /dev/disk/by-id/scsi-0DO_Volume_volume-fra1-02
+        run: |
+          cat > ${ANSIBLE_INVENTORY_PATH} << EOF
+          [xsnippet]
+          ${ANSIBLE_SSH_HOST} ansible_user=${ANSIBLE_SSH_USER} ansible_ssh_private_key_file=${DEPLOYMENT_SSH_KEY_PATH}
+          EOF
+
+          ansible-playbook \
+            -vv \
+            --extra-vars "{\"xsnippet_db_external_volume\": \"${VOLUME_ID}\"}" \
+            --inventory ${ANSIBLE_INVENTORY_PATH} \
+            ${ANSIBLE_PLAYBOOK_PATH}
+
+      - name: Smoke test
+        run: |
+          for i in `seq 180`; do
+            curl https://xsnippet.org/v1/syntaxes && exit 0 || sleep 1
+          done
+
+          echo "https://xsnippet.org/v1/syntaxes is unavailable after 180s. Giving up."
+          exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Tests
+name: ci
 
 on:
   push:


### PR DESCRIPTION
Add a GitHub Action workflow that is triggered on push to master or
manually that deploys from master branch to production. This is the
first step towards infrastructure as a code. Further enhancements could
be to move production variables from job definition to ansible variables
file.