### PR TITLE
CD: Add xsnippet.org to known hosts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,6 +33,10 @@ jobs:
         env:
           DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
         run: |
+          # Ensure that servers we're deploying to are known. Otherwise,
+          # Ansible may fail with host key verification error.
+          mkdir -p ~/.ssh && echo "${{ secrets.SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+
           ansible-playbook \
             -vv \
             -e ansible_ssh_private_key_file=${DEPLOYMENT_SSH_KEY_PATH} \


### PR DESCRIPTION
    Currently our CD pipeline is dead since Ansible fails with "Host key
    verification failed" error. It's unclear why it started to fail like
    that all of a sudden, yet it's known that one must manage SSH
    known_hosts in case of automation before running pipelines.

    This patch adds xsnippet.org SSH fingerprint to ~/.ssh/known_hosts on
    the runner node before executing Ansible. The fingerprint is stored in
    secrets for easier management (although it's not a secret exactly).
