### PR TITLE
Add localhost tasks to smoke test deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -41,12 +41,3 @@ jobs:
             -e ansible_ssh_private_key_file="${{ steps.ssh-key.outputs.uri }}" \
             --inventory inventories/production \
             site.yml
-
-      - name: Smoke test
-        run: |
-          for i in `seq 180`; do
-            curl https://xsnippet.org/v1/syntaxes && exit 0 || sleep 1
-          done
-
-          echo "https://xsnippet.org/v1/syntaxes is unavailable after 180s. Giving up."
-          exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,11 @@ jobs:
           echo ::set-output name=uri::$VOLUME_DEVICE
         id: volume-device
 
+      - name: Add server names to /etc/hosts
+        run: |
+          echo "127.0.0.1 xsnippet.local" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 api.xsnippet.local" | sudo tee -a /etc/hosts
+
       - name: Run the playbook
         run: |
           ansible-playbook \
@@ -64,12 +69,3 @@ jobs:
             -e volume_device="${{ steps.volume-device.outputs.uri }}" \
             --inventory inventories/ci \
             site.yml
-
-      - name: Smoke test
-        run: |
-          for i in `seq 180`; do
-            curl http://localhost/v1/syntaxes && exit 0 || sleep 1
-          done
-
-          echo "http://localhost/v1/syntaxes is unavailable after 180s. Giving up."
-          exit 1

--- a/site.yml
+++ b/site.yml
@@ -12,6 +12,7 @@
         name: acl
         state: present
       become: true
+
   roles:
     - role: firewall
     - role: volume
@@ -20,3 +21,22 @@
     - role: caddy
     - role: xsnippet_api
     - role: xsnippet_web
+
+
+- hosts: localhost
+  vars:
+    _validate_certs: "{{ lookup('env', 'CI') is falsy }}"
+  tasks:
+    - name: Test that xsnippet-api is up and running
+      ansible.builtin.uri:
+        url: "https://{{ xsnippet_api_server_name }}/v1/snippets"
+        method: GET
+        status_code: 200
+        validate_certs: "{{ _validate_certs }}"
+
+    - name: Test that xsnippet-web is up and running
+      ansible.builtin.uri:
+        url: "https://{{ xsnippet_web_server_name }}"
+        method: GET
+        status_code: 200
+        validate_certs: "{{ _validate_certs }}"


### PR DESCRIPTION
Add two tasks to smoke test the deployment. In particular, the tasks are
checking that xsnippet-api and xsnippet-web are up and running, and
served via HTTPS. Needless to say that in case of CI, TLS cert
validation is turned off since the certs are self-signed.