### PR TITLE
Use 'raw.xsnippet.org' to server raw content from

### DIFF
--- a/inventories/ci/group_vars/all.yml
+++ b/inventories/ci/group_vars/all.yml
@@ -10,4 +10,5 @@ volume_binds:
 xsnippet_api_user: xsnippet-api
 xsnippet_api_database_url: postgresql:///{{ postgres_users[0].database }}?host=/run/postgresql
 xsnippet_api_server_name: api.xsnippet.local
+xsnippet_raw_server_name: raw.xsnippet.local
 xsnippet_web_server_name: xsnippet.local

--- a/inventories/production/group_vars/all.yml
+++ b/inventories/production/group_vars/all.yml
@@ -12,4 +12,5 @@ volume_device: /dev/disk/by-id/scsi-0DO_Volume_xsnippet-state
 xsnippet_api_user: xsnippet-api
 xsnippet_api_database_url: postgresql:///{{ postgres_users[0].database }}?host=/run/postgresql
 xsnippet_api_server_name: api.xsnippet.org
+xsnippet_raw_server_name: raw.xsnippet.org
 xsnippet_web_server_name: xsnippet.org

--- a/roles/xsnippet_raw/meta/main.yml
+++ b/roles/xsnippet_raw/meta/main.yml
@@ -1,0 +1,10 @@
+---
+
+argument_specs:
+  main:
+    options:
+      xsnippet_raw_server_name:
+        type: str
+        required: true
+        description: |
+          The server name (domain) to serve requests from.

--- a/roles/xsnippet_raw/tasks/main.yml
+++ b/roles/xsnippet_raw/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Configure caddy for xsnippet-raw
+  ansible.builtin.template:
+    src: caddy.j2
+    dest: "{{ (caddy_confd_path, 'xsnippet-raw.caddy') | path_join }}"
+    mode: u=rw,g=r,o=r
+  notify: caddy-restart
+  become: true

--- a/roles/xsnippet_raw/templates/caddy.j2
+++ b/roles/xsnippet_raw/templates/caddy.j2
@@ -1,0 +1,9 @@
+{{ xsnippet_raw_server_name }} {
+  encode gzip zstd
+  log
+
+  rewrite * /v1/snippets{path}?
+  reverse_proxy {{ xsnippet_api_address }}:{{ xsnippet_api_port }} {
+    header_up Accept text/plain
+  }
+}

--- a/roles/xsnippet_web/templates/caddy.j2
+++ b/roles/xsnippet_web/templates/caddy.j2
@@ -6,6 +6,8 @@
     path_regexp ^/(?P<snippet_id>[a-zA-Z0-9]+)/raw/?$
   }
 
+  # DEPRECATED: As of Jan 07, 2022, this route is deprecated in favor of
+  # separate hostname: raw.xsnippet.org.
   handle @raw_snippet {
     rewrite @raw_snippet /v1/snippets/{http.regexp.snippet_id}?
     reverse_proxy localhost:8080 {

--- a/roles/xsnippet_web/templates/conf.json.j2
+++ b/roles/xsnippet_web/templates/conf.json.j2
@@ -1,4 +1,4 @@
 {
     "API_BASE_URI": "//{{ xsnippet_api_server_name }}",
-    "RAW_SNIPPET_URI_FORMAT": "//{{ xsnippet_web_server_name }}/%s/raw"
+    "RAW_SNIPPET_URI_FORMAT": "//{{ xsnippet_raw_server_name }}/%s"
 }

--- a/site.yml
+++ b/site.yml
@@ -19,4 +19,5 @@
     - role: postgres
     - role: caddy
     - role: xsnippet_api
+    - role: xsnippet_raw
     - role: xsnippet_web


### PR DESCRIPTION
Historically XSnippet served its raw content via main domain using a
specially formatted URL: `xsnippet.org/:id/raw`. It served us well for a
time being, yet it has its own drawbacks:

 * The pattern matching and rewriting rule in Caddyfile for xsnippet-web
   is a bit complicated. I spent ~2 hours searching the Internet in
   order to find that solution. It's not well documented.

 * We claim that xsnippet-web is a SPA, and hence URLs are belonged and
   processed by the SPA. Yet we have this exception, i.e. raw route,
   that must go the other way.

 * Serving raw content and SPA is completely different use cases. It
   will be more readable and maintainable if we separate them.

This patch moves raw content serving from special route of xsnippet.org
to separate domain, raw.xsnippet.org.