### PR TITLE
Create backups of PostgreSQL databases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v5.3.1
+    rev: v5.3.2
     hooks:
       - id: ansible-lint
         args: [-x, meta-no-info]

--- a/inventories/ci/group_vars/all.yml
+++ b/inventories/ci/group_vars/all.yml
@@ -3,9 +3,13 @@
 postgres_users:
   - database: "{{ xsnippet_api_user }}"
     username: "{{ xsnippet_api_user }}"
+    backup_schedule: "*-*-* 3:00:00"  # every night at 03:00 UTC
 volume_binds:
   - path: /data/postgresql
     mountpoint: /var/lib/postgresql
+    mode: u=rwx,g=rx,o=
+  - path: /data/postgresql-backups
+    mountpoint: /var/lib/postgresql-backups
     mode: u=rwx,g=rx,o=
 xsnippet_api_user: xsnippet-api
 xsnippet_api_database_url: postgresql:///{{ postgres_users[0].database }}?host=/run/postgresql

--- a/inventories/production/group_vars/all.yml
+++ b/inventories/production/group_vars/all.yml
@@ -4,9 +4,13 @@ caddy_email: dev@xsnippet.org
 postgres_users:
   - database: "{{ xsnippet_api_user }}"
     username: "{{ xsnippet_api_user }}"
+    backup_schedule: "*-*-* 3:00:00"  # every night at 03:00 UTC
 volume_binds:
   - path: /data/postgresql
     mountpoint: /var/lib/postgresql
+    mode: u=rwx,g=rx,o=
+  - path: /data/postgresql-backups
+    mountpoint: /var/lib/postgresql-backups
     mode: u=rwx,g=rx,o=
 volume_device: /dev/disk/by-id/scsi-0DO_Volume_xsnippet-state
 xsnippet_api_user: xsnippet-api

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 postgres_users: []
+postgres_backups_dir: /var/lib/postgresql-backups

--- a/roles/postgres/meta/main.yml
+++ b/roles/postgres/meta/main.yml
@@ -3,6 +3,11 @@
 argument_specs:
   main:
     options:
+      postgres_backups_dir:
+        type: str
+        description: |
+          The directory where to store PostgreSQL backups.
+        default: /var/lib/postgresql-backups
       postgres_users:
         type: list
         elements: dict
@@ -17,6 +22,12 @@ argument_specs:
             required: true
             description: |
               The username to create with permissions to the database.
+          backup_schedule:
+            type: str
+            required: false
+            description: |
+              The time of when database backups should be triggered. Uses the systemd calendar event expression syntax (see man 7 systemd.time).
+              If not set, backups will not be created.
         default: []
         description: |
           The list of database/username pairs to create.

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -56,3 +56,26 @@
   with_items: "{{ postgres_users }}"
   become: true
   become_user: postgres
+
+- name: Add a service template that allows creating backups of postgresql databases
+  ansible.builtin.template:
+    src: postgres-backups@.service.j2
+    dest: /usr/lib/systemd/system/postgres-backups@.service
+  become: true
+
+- name: Add timers triggering backups of postgresql databases
+  ansible.builtin.template:
+    src: postgres-backups@.timer.j2
+    dest: /usr/lib/systemd/system/postgres-backups@{{ item.database }}.timer
+  with_items: "{{ postgres_users }}"
+  when: item.backup_schedule is defined and item.backup_schedule
+  become: true
+
+- name: Enable timers triggering backups of postgresql databases
+  ansible.builtin.systemd:
+    name: postgres-backups@{{ item.database }}.timer
+    state: started
+    enabled: true
+  with_items: "{{ postgres_users }}"
+  when: item.backup_schedule is defined and item.backup_schedule
+  become: true

--- a/roles/postgres/templates/postgres-backups@.service.j2
+++ b/roles/postgres/templates/postgres-backups@.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description = Back up the PostgresSQL database `%i`
+Requires = postgresql.service
+After = postgresql.service
+
+[Service]
+User = postgres
+Group = postgres
+WorkingDirectory = {{ postgres_backups_dir }}
+ExecStartPre = +/usr/bin/chown postgres:postgres {{ postgres_backups_dir }}
+ExecStart = /usr/bin/bash -c "/usr/bin/pg_dump --compress=9 --no-owner --format=p --file=%i_$(TZ=UTC date +%%Y%%m%%d-%%H%%M%%S).sql.gz %i"

--- a/roles/postgres/templates/postgres-backups@.timer.j2
+++ b/roles/postgres/templates/postgres-backups@.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Back up the PostgresSQL database `{{ item.database }}`
+
+[Timer]
+Unit=postgres-backups@{{ item.database }}.service
+OnCalendar={{ item.backup_schedule }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds a new systemd timer/service pair that triggers a plain-text SQL
dump (compressed with gzip) of a PostgreSQL database if backup schedule
is set in the corresponding `postgres_users` entry. The backups are
stored in `/var/lib/postgresql-backups` and are not uploaded anywhere
else yet (that will be done separately in a different role).

We could put this logic into a new role, but it seemed like a natural
extension of the `postgres_users` configuration which already lives in
the `postgres` role.