### PR TITLE
Use "127.0.0.1" instead of "localhost"

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
@@ -20,6 +20,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade ansible
+          ansible-galaxy collection install --force ansible.posix
+          ansible-galaxy collection install --force community.postgresql
 
       - name: Setup a deployment SSH key
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 defaults:
   run:
@@ -24,6 +24,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pre-commit
+          ansible-galaxy collection install --force ansible.posix
+          ansible-galaxy collection install --force community.postgresql
 
       - name: Run pre-commit
         run: |
@@ -38,6 +40,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade ansible
+          ansible-galaxy collection install --force ansible.posix
+          ansible-galaxy collection install --force community.postgresql
 
       - name: Remove pre-baked PostgreSQL
         run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v5.3.2
+    rev: v6.22.0
     hooks:
       - id: ansible-lint
         args: [-x, meta-no-info]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir /opt/xsnippet && \
 
 COPY xsnippet-api.sh /opt/xsnippet/xsnippet-api.sh
 
-ENV ROCKET_ADDRESS=localhost \
+ENV ROCKET_ADDRESS=127.0.0.1 \
     ROCKET_PORT=8000 \
     RUST_BACKTRACE=1
 EXPOSE $ROCKET_PORT

--- a/roles/caddy/handlers/main.yml
+++ b/roles/caddy/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: caddy-restart
+- name: Caddy restart
   ansible.builtin.systemd:
     name: caddy.service
     state: restarted

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -37,7 +37,7 @@
     src: caddyfile.j2
     dest: /etc/caddy/Caddyfile
     mode: u=rw,g=r,o=r
-  notify: caddy-restart
+  notify: Caddy restart
   become: true
 
 - name: Create 'conf.d' directory to store virtual hosts

--- a/roles/firewall/handlers/main.yml
+++ b/roles/firewall/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: firewall-restart
+- name: Firewall restart
   ansible.builtin.systemd:
     name: nftables
     state: restarted

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -17,7 +17,7 @@
     src: nftables.conf
     dest: /etc/nftables.conf
     mode: u=rw,g=r,o=r
-  notify: firewall-restart
+  notify: Firewall restart
   become: true
 
 - name: Enable and start nftables

--- a/roles/goaccess/handlers/main.yml
+++ b/roles/goaccess/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: goaccess-restart
+- name: Goaccess restart
   ansible.builtin.systemd:
     name: "{{ item }}"
     state: restarted

--- a/roles/goaccess/tasks/main.yml
+++ b/roles/goaccess/tasks/main.yml
@@ -32,7 +32,7 @@
     state: present
   become: true
 
-- name: Create '{{ goaccess_user }}' user
+- name: Create user '{{ goaccess_user }}'
   ansible.builtin.user:
     name: "{{ goaccess_user }}"
     shell: /sbin/nologin
@@ -54,7 +54,7 @@
     src: goaccess.conf.j2
     dest: "{{ goaccess_sysconf_path }}"
     mode: u=rw,g=r,o=r
-  notify: goaccess-restart
+  notify: Goaccess restart
   become: true
 
 - name: Create goaccess systemd unit
@@ -85,5 +85,5 @@
     src: caddy.j2
     dest: "{{ (caddy_confd_path, 'goaccess.caddy') | path_join }}"
     mode: u=rw,g=r,o=r
-  notify: caddy-restart
+  notify: Caddy restart
   become: true

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -57,6 +57,17 @@
   become: true
   become_user: postgres
 
+- name: Grant users permissions to create tables in the schema `public`
+  community.postgresql.postgresql_privs:
+    db: "{{ item.database }}"
+    privs: CREATE
+    type: schema
+    objs: public
+    role: "{{ item.username }}"
+  with_items: "{{ postgres_users }}"
+  become: true
+  become_user: postgres
+
 - name: Add a service template that allows creating backups of postgresql databases
   ansible.builtin.template:
     src: postgres-backups@.service.j2

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -31,7 +31,7 @@
     name:
       - postgresql
       - postgresql-contrib
-      - python3-psycopg2  # required for 'ansible.builtin.postgresql_*' modules
+      - python3-psycopg2  # required for 'community.postgresql.postgresql_*' modules
     state: present
   become: true
 
@@ -43,14 +43,14 @@
   become: true
 
 - name: Setup postgresql databases
-  ansible.builtin.postgresql_db:
+  community.postgresql.postgresql_db:
     name: "{{ item.database }}"
   with_items: "{{ postgres_users }}"
   become: true
   become_user: postgres
 
 - name: Setup postgresql users
-  ansible.builtin.postgresql_user:
+  community.postgresql.postgresql_user:
     db: "{{ item.database }}"
     user: "{{ item.username }}"
   with_items: "{{ postgres_users }}"
@@ -61,12 +61,14 @@
   ansible.builtin.template:
     src: postgres-backups@.service.j2
     dest: /usr/lib/systemd/system/postgres-backups@.service
+    mode: 'u=rw,g=r,o=r'
   become: true
 
 - name: Add timers triggering backups of postgresql databases
   ansible.builtin.template:
     src: postgres-backups@.timer.j2
     dest: /usr/lib/systemd/system/postgres-backups@{{ item.database }}.timer
+    mode: 'u=rw,g=r,o=r'
   with_items: "{{ postgres_users }}"
   when: item.backup_schedule is defined and item.backup_schedule
   become: true

--- a/roles/volume/tasks/main.yml
+++ b/roles/volume/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: If not, create a new filesystem
   ansible.builtin.command: "mkfs.{{ volume_fs }} {{ volume_device }}"
   when: not volume_has_fs
+  changed_when: true
   become: true
 
 - name: Create the mount point directory

--- a/roles/xsnippet_api/defaults/main.yml
+++ b/roles/xsnippet_api/defaults/main.yml
@@ -5,6 +5,6 @@ xsnippet_api_src_artifact: https://github.com/xsnippet/xsnippet-api/archive/refs
 xsnippet_api_root: /opt/xsnippet-api
 xsnippet_api_src_root: "{{ (xsnippet_api_root, '.src') | path_join }}"
 xsnippet_api_user: xsnippet-api
-xsnippet_api_address: localhost
+xsnippet_api_address: 127.0.0.1
 xsnippet_api_port: 8080
 xsnippet_api_syntaxes: "{{ lookup('file', 'syntaxes.txt').splitlines() }}"

--- a/roles/xsnippet_api/handlers/main.yml
+++ b/roles/xsnippet_api/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: xsnippet-api-restart
+- name: XSnippet API restart
   ansible.builtin.systemd:
     name: xsnippet-api.service
     state: restarted

--- a/roles/xsnippet_api/meta/main.yml
+++ b/roles/xsnippet_api/meta/main.yml
@@ -31,7 +31,7 @@ argument_specs:
           will be created.
       xsnippet_api_address:
         type: str
-        default: localhost
+        default: 127.0.0.1
         description: |
           The host address to bind xsnippet-api to.
       xsnippet_api_port:

--- a/roles/xsnippet_api/tasks/main.yml
+++ b/roles/xsnippet_api/tasks/main.yml
@@ -15,7 +15,7 @@
     state: present
   become: true
 
-- name: Create '{{ xsnippet_api_user }}' user
+- name: Create user '{{ xsnippet_api_user }}'
   ansible.builtin.user:
     name: "{{ xsnippet_api_user }}"
     shell: /sbin/nologin
@@ -64,7 +64,7 @@
     group: root
     mode: u=rwx,g=rx,o=rx
     remote_src: true
-  notify: xsnippet-api-restart
+  notify: XSnippet API restart
   become: true
 
 - name: Create runtime configuration
@@ -72,7 +72,7 @@
     src: systemd.env.j2
     dest: "{{ xsnippet_api_systemd_env }}"
     mode: u=rw,g=r,o=r
-  notify: xsnippet-api-restart
+  notify: XSnippet API restart
   become: true
 
 - name: Create systemd service unit
@@ -95,5 +95,5 @@
     src: caddy.j2
     dest: "{{ (caddy_confd_path, 'xsnippet-api.caddy') | path_join }}"
     mode: u=rw,g=r,o=r
-  notify: caddy-restart
+  notify: Caddy restart
   become: true

--- a/roles/xsnippet_raw/tasks/main.yml
+++ b/roles/xsnippet_raw/tasks/main.yml
@@ -5,5 +5,5 @@
     src: caddy.j2
     dest: "{{ (caddy_confd_path, 'xsnippet-raw.caddy') | path_join }}"
     mode: u=rw,g=r,o=r
-  notify: caddy-restart
+  notify: Caddy restart
   become: true

--- a/roles/xsnippet_web/tasks/main.yml
+++ b/roles/xsnippet_web/tasks/main.yml
@@ -29,5 +29,5 @@
     src: caddy.j2
     dest: "{{ (caddy_confd_path, 'xsnippet-web.caddy') | path_join }}"
     mode: u=rw,g=r,o=r
-  notify: caddy-restart
+  notify: Caddy restart
   become: true

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,7 @@
 ---
 
-- hosts: xsnippet
+- name: "Deploy a single-node XSnippet instance"
+  hosts: xsnippet
   pre_tasks:
     # When Ansible is connected via unprivileged user, and 'become_user' is not
     # root, Ansible requires 'acl' to share the ansible module between two
@@ -25,7 +26,8 @@
     - role: goaccess
 
 
-- hosts: localhost
+- name: "Smoke test"
+  hosts: localhost
   vars:
     _validate_certs: "{{ lookup('env', 'CI') is falsy }}"
   tasks:


### PR DESCRIPTION
Apparently, in Rocket >= 0.5 `ROCKET_ADDRESS` only accepts IP addresses but not hostnames: "Use only IP addresses for the address configuration parameter." [1]. xsnippet-api fails to start, unless we pass "127.0.0.1" (or "::1") instead of "localhost".

[1] https://rocket.rs/v0.5-rc/guide/upgrading/#configuration