### PR TITLE
Fix GitHub CI warnings

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -14,7 +14,7 @@ jobs:
     concurrency: xsnippet.org
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Ansible
         run: |
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "${{ secrets.DEPLOYMENT_SSH_KEY }}" > $DEPLOYMENT_SSH_KEY_PATH
           chmod 0600 $DEPLOYMENT_SSH_KEY_PATH
-          echo ::set-output name=uri::$DEPLOYMENT_SSH_KEY_PATH
+          echo "uri=$DEPLOYMENT_SSH_KEY_PATH" >> $GITHUB_OUTPUT
         id: ssh-key
 
       - name: Deploy to production

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       - name: Install pre-commit
         run: |
@@ -34,7 +36,7 @@ jobs:
   ansible:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Ansible
         run: |
@@ -58,7 +60,7 @@ jobs:
           dd if=/dev/zero of=$VOLUME_IMAGE bs=1M count=1024
           sudo losetup $VOLUME_DEVICE $VOLUME_IMAGE
 
-          echo ::set-output name=uri::$VOLUME_DEVICE
+          echo "uri=$VOLUME_DEVICE" >> $GITHUB_OUTPUT
         id: volume-device
 
       - name: Add server names to /etc/hosts

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,9 +31,10 @@ jobs:
     steps:
       - id: release-params
         name: Look up the Github release by tag/name and prepare a list of tags to be attached to the Docker image
+        shell: python
         run: |
-          python3 <<EOF
           import json
+          import os
           import urllib.error as e
           import urllib.request as r
 
@@ -65,12 +66,12 @@ jobs:
           if release['tag_name'] != '${{ github.event.inputs.release_tag }}':
             tags.add('${{ github.event.inputs.release_tag }}')
 
-          print(f"::set-output name=release_tag::{release['tag_name']}")
-          print(f"::set-output name=image_tags::{','.join('${{ github.event.inputs.image_name }}:' + t for t in tags)}")
-          EOF
+          with open(os.environ["GITHUB_OUTPUT"], "at") as f:
+            f.write(f"release_tag={release['tag_name']}\n")
+            f.write(f"image_tags={','.join('${{ github.event.inputs.image_name }}:' + t for t in tags)}\n")
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
See https://github.com/xsnippet/xsnippet-infra/actions/runs/6869023083

* actions/checkout@v2 and actions/setup-python@v2 are using a deprecated NodeJS version
* the new setup-python action wants us to specify the Python version explicitly
* setting action output values via stdout is also deprecated (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)