### PR TITLE
Actually run backup rotation in postgres-backups@.service

### DIFF
--- a/roles/postgres/templates/postgres-backups@.service.j2
+++ b/roles/postgres/templates/postgres-backups@.service.j2
@@ -9,4 +9,4 @@ Group = postgres
 WorkingDirectory = {{ postgres_backups_dir }}
 ExecStartPre = +/usr/bin/chown postgres:postgres {{ postgres_backups_dir }}
 ExecStart = /usr/bin/bash -c "/usr/bin/pg_dump --compress=9 --no-owner --format=p --file=%i_$(TZ=UTC date +%%Y%%m%%d-%%H%%M%%S).sql.gz %i"
-ExecStartPost = /usr/bin/python3 /usr/local/bin/rotate.py --keep 30 --dir {{ postgres_backups_dir }}
+ExecStartPost = /usr/bin/python3 /usr/local/bin/rotate.py --no-dry-run --keep 30 --dir {{ postgres_backups_dir }}


### PR DESCRIPTION
Dry run example:

```shell
# systemctl status postgres-backups@xsnippet-api.service
○ postgres-backups@xsnippet-api.service - Back up the PostgresSQL database `xsnippet-api`
     Loaded: loaded (/lib/systemd/system/postgres-backups@.service; static)
     Active: inactive (dead) since Fri 2024-09-13 03:00:04 UTC; 2h 13min ago
TriggeredBy: ● postgres-backups@xsnippet-api.timer
    Process: 2122016 ExecStartPre=/usr/bin/chown postgres:postgres /var/lib/postgresql-backups (code=exited, status=0/SUCCESS)
    Process: 2122017 ExecStart=/usr/bin/bash -c /usr/bin/pg_dump --compress=9 --no-owner --format=p --file=xsnippet-api_$(TZ=UTC date +%Y%m%d-%H%M%S).sql.gz xsnippet-api (c>
    Process: 2122018 ExecStartPost=/usr/bin/python3 /usr/local/bin/rotate.py --keep 30 --dir /var/lib/postgresql-backups (code=exited, status=0/SUCCESS)
   Main PID: 2122017 (code=exited, status=0/SUCCESS)
        CPU: 2.154s

Sep 13 03:00:01 xsnippet systemd[1]: Starting Back up the PostgresSQL database `xsnippet-api`...
Sep 13 03:00:02 xsnippet python3[2122018]: Dry run. No changes will be made.
Sep 13 03:00:02 xsnippet python3[2122018]: Used space: 30 files, 133682908 bytes
Sep 13 03:00:02 xsnippet python3[2122018]: Freed space: 34 files, 151342898 bytes
Sep 13 03:00:02 xsnippet systemd[1]: Started Back up the PostgresSQL database `xsnippet-api`.
Sep 13 03:00:04 xsnippet systemd[1]: postgres-backups@xsnippet-api.service: Deactivated successfully.
Sep 13 03:00:04 xsnippet systemd[1]: postgres-backups@xsnippet-api.service: Consumed 2.154s CPU time.
```