### PR TITLE
postgres: create a database with an owner already set

### DIFF
--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -42,28 +42,17 @@
     enabled: true
   become: true
 
-- name: Setup postgresql databases
-  community.postgresql.postgresql_db:
-    name: "{{ item.database }}"
-  with_items: "{{ postgres_users }}"
-  become: true
-  become_user: postgres
-
 - name: Setup postgresql users
   community.postgresql.postgresql_user:
-    db: "{{ item.database }}"
     user: "{{ item.username }}"
   with_items: "{{ postgres_users }}"
   become: true
   become_user: postgres
 
-- name: Grant users permissions to create tables in the schema `public`
-  community.postgresql.postgresql_privs:
-    db: "{{ item.database }}"
-    privs: CREATE
-    type: schema
-    objs: public
-    role: "{{ item.username }}"
+- name: Setup postgresql databases
+  community.postgresql.postgresql_db:
+    name: "{{ item.database }}"
+    owner: "{{ item.username }}"
   with_items: "{{ postgres_users }}"
   become: true
   become_user: postgres


### PR DESCRIPTION
In the current setup databases are owned by the admin role `postgres`, and we separately grant users the permission to create their own tables in the schema `public`. I believe our intention was to make users the owners of the corresponding databases, effectively granting them all permissions w/o any extra steps.

This will make the tests and new databases consistent with our production instance where the database is owned by role `xsnippet-api`.