### PR TITLE
postgres: change backup format from plain SQL to pg_dump custom

### DIFF
--- a/roles/postgres/templates/postgres-backups@.service.j2
+++ b/roles/postgres/templates/postgres-backups@.service.j2
@@ -8,5 +8,5 @@ User = postgres
 Group = postgres
 WorkingDirectory = {{ postgres_backups_dir }}
 ExecStartPre = +/usr/bin/chown postgres:postgres {{ postgres_backups_dir }}
-ExecStart = /usr/bin/bash -c "/usr/bin/pg_dump --compress=9 --no-owner --format=p --file=%i_$(TZ=UTC date +%%Y%%m%%d-%%H%%M%%S).sql.gz %i"
+ExecStart = /usr/bin/bash -c "/usr/bin/pg_dump --compress=9 --format=c --file=%i_$(TZ=UTC date +%%Y%%m%%d-%%H%%M%%S).pgc %i"
 ExecStartPost = /usr/bin/python3 /usr/local/bin/rotate.py --no-dry-run --keep 30 --dir {{ postgres_backups_dir }}


### PR DESCRIPTION
I'm experimenting with implementing the backup restore step and I ran into a few complications:

* pg_restore does not like plain SQL and prefers this format they refer to as "custom"

* psql does not allow us to change the role to `xsnippet-api` before restoring the backup in an Ansible task, so all objects end up being owned by the admin role `postgres`... And we can't use `become` because the system user `xsnippet-api` does not exist at that point yet

Switching to the custom format allows us to have this symmetry between pg_dump and pg_restore, and preserve/restore the correct owner value on all database objects. pg_restore also allows to skip the commands setting ownership, e.g. if we want to migrate to a different role.