### PR TITLE
Use infinite restarts for xsnippet-api.service

### DIFF
--- a/roles/xsnippet_api/templates/systemd.service.j2
+++ b/roles/xsnippet_api/templates/systemd.service.j2
@@ -2,6 +2,7 @@
 Description = XSnippet API
 After = network.target network-online.target
 Wants = network-online.target
+StartLimitIntervalSec = 0
 
 [Service]
 WorkingDirectory = {{ xsnippet_api_root }}
@@ -11,6 +12,7 @@ Group = {{ xsnippet_api_user }}
 ExecStartPre = {{ xsnippet_api_database_upgrade_bin }}
 ExecStart = {{ xsnippet_api_bin }}
 Restart = on-failure
+RestartSec = 30
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
systemd defaults are fairly strict (<= 5 restarts within 10s) before it gives up on the service. And we would prefer the service to recover automatically after transient failures even if takes longer than that.

E.g. yesterday, I found that xsnippet-api had been down after the last machine reboot because it could not fetch the Auth0 key on start, but the same thing could happen with database connection as well.