### PR TITLE
Add a dependency on postgresql.service to xsnippet-api.service

### DIFF
--- a/roles/xsnippet_api/templates/systemd.service.j2
+++ b/roles/xsnippet_api/templates/systemd.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description = XSnippet API
-After = network.target network-online.target
-Wants = network-online.target
+After = network.target network-online.target postgresql.service
+Wants = network-online.target postgresql.service
 StartLimitIntervalSec = 0
 
 [Service]


### PR DESCRIPTION
xsnippet-api tries to connect to PostgreSQL on start and will fail if it's not available. Declare this dependency in systemd, so that the services always come up in the right order.