### PR TITLE
Use a jumphost for continues deployment

### DIFF
--- a/inventories/production/hosts
+++ b/inventories/production/hosts
@@ -1,2 +1,6 @@
 [xsnippet]
-2a02:8084:4:e480:244a:d5a5:ac59:617d ansible_user=provisioner
+2a02:8084:4:e480:244a:d5a5:ac59:617d
+
+[xsnippet:vars]
+ansible_user = provisioner
+ansible_ssh_common_args = -J bunny@hoth.kalnytskyi.com


### PR DESCRIPTION
Unfortunately, IPv6 is not available on GitHub Action runners. This means we cannot deploy directly from runners to our server. In order to support continue deployment, we need a jumphost that would act as a layer that acts as a router that supports both IPv4 and IPv6.