### PR TITLE
Use .ssh/config to setup SSH proxy jump

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,10 +37,20 @@ jobs:
           # Ensure that servers we're deploying to are known. Otherwise,
           # Ansible may fail with host key verification error.
           mkdir -p ~/.ssh && echo "${{ secrets.SSH_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          cat <<EOF > ~/.ssh/config
+          Host _jumphost
+            User bunny
+            HostName hoth.kalnytskyi.com
+            IdentityFile ${{ steps.ssh-key.outputs.uri }}
+
+          Host xsnippet.org
+            HostName 2a02:8084:4:e480:244a:d5a5:ac59:617d
+            ProxyJump _jumphost
+            IdentityFile ${{ steps.ssh-key.outputs.uri }}
+          EOF
 
           ansible-playbook \
             -vv \
-            -e ansible_ssh_private_key_file="${{ steps.ssh-key.outputs.uri }}" \
             -e goaccess_basicauth_password="${{ secrets.GOACCESS_PASSWORD }}" \
             --inventory inventories/production \
             site.yml

--- a/inventories/production/hosts
+++ b/inventories/production/hosts
@@ -1,6 +1,5 @@
 [xsnippet]
-2a02:8084:4:e480:244a:d5a5:ac59:617d
+xsnippet.org
 
 [xsnippet:vars]
 ansible_user = provisioner
-ansible_ssh_common_args = -J bunny@hoth.kalnytskyi.com


### PR DESCRIPTION
Unfortunately, my previous attempt to route deployment through a jumphost[^1] doesn't work. Turns out that specifying a proxyjump host inline doesn't support specifying an SSH key to authenticate with. It worked well on my machine because some _default_ key was used transparently, but it fails on CD where no such key exist.

The new approach tries to address the problem by moving away from inline SSH configuration towards the .ssh/config file, which has everything needed specified.

[^1]: 7aec7734e7d81482675ee9e64c0504fae341abf1