### PR TITLE
Fix apt-key deprecation warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install pre-commit
         run: |
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Install pytest / Ruff
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,4 @@ repos:
     rev: v6.22.0
     hooks:
       - id: ansible-lint
-        args: [-x, meta-no-info]
+        args: [-x, "meta-no-info,no-handler"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.22.0
+    rev: v25.12.2
     hooks:
       - id: ansible-lint
         args: [-x, "meta-no-info,no-handler"]

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -12,19 +12,25 @@
     state: present
   become: true
 
-- name: Add caddy repository signing key
-  ansible.builtin.apt_key:
-    url: "{{ caddy_apt_repo_gpg }}"
-    state: present
-  become: true
-
 - name: Add caddy repository
-  ansible.builtin.apt_repository:
-    repo: "{{ item }}"
-    state: present
-    filename: caddy
-  with_items: "{{ caddy_apt_repo }}"
+  ansible.builtin.deb822_repository:
+    name: caddy
+    types:
+      - deb
+      - deb-src
+    uris: "{{ caddy_apt_repo }}"
+    suites: any-version
+    components:
+      - main
+    signed_by: "{{ caddy_apt_repo_gpg }}"
   become: true
+  register: caddy_repo_result
+
+- name: Update apt cache if needed
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  when: caddy_repo_result.changed
 
 - name: Install the caddy package
   ansible.builtin.apt:

--- a/roles/caddy/vars/main.yml
+++ b/roles/caddy/vars/main.yml
@@ -4,7 +4,5 @@ caddy_apt_prerequisite_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-caddy_apt_repo:
-  - deb https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
-  - deb-src https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main
+caddy_apt_repo: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
 caddy_apt_repo_gpg: https://dl.cloudsmith.io/public/caddy/stable/gpg.key

--- a/roles/goaccess/tasks/main.yml
+++ b/roles/goaccess/tasks/main.yml
@@ -12,19 +12,24 @@
     state: present
   become: true
 
-- name: Add goaccess repository signing key
-  ansible.builtin.apt_key:
-    url: "{{ goaccess_apt_repo_gpg }}"
-    state: present
-  become: true
-
 - name: Add goaccess repository
-  ansible.builtin.apt_repository:
-    repo: "{{ item }}"
-    state: present
-    filename: goaccess
-  with_items: "{{ goaccess_apt_repo }}"
+  ansible.builtin.deb822_repository:
+    name: goaccess
+    types:
+      - deb
+    uris: "{{ goaccess_apt_repo }}"
+    suites: "{{ ansible_facts['distribution_release'] }}"
+    components:
+      - main
+    signed_by: "{{ goaccess_apt_repo_gpg }}"
   become: true
+  register: goaccess_repo_result
+
+- name: Update apt cache if needed
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  when: goaccess_repo_result.changed
 
 - name: Install the goaccess package
   ansible.builtin.apt:

--- a/roles/goaccess/vars/main.yml
+++ b/roles/goaccess/vars/main.yml
@@ -4,7 +4,6 @@ goaccess_apt_prerequisite_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-goaccess_apt_repo:
-  - deb https://deb.goaccess.io/ {{ ansible_distribution_release }} main
+goaccess_apt_repo: https://deb.goaccess.io/
 goaccess_apt_repo_gpg: https://deb.goaccess.io/gnugpg.key
 goaccess_sysconf_path: /etc/goaccess/goaccess.conf

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -12,19 +12,25 @@
     state: present
   become: true
 
-- name: Add postgres repository signing key
-  ansible.builtin.apt_key:
-    url: "{{ postgres_apt_repo_gpg }}"
-    state: present
-  become: true
-
 - name: Add postgres repository
-  ansible.builtin.apt_repository:
-    repo: "{{ item }}"
-    state: present
-    filename: postgres
-  with_items: "{{ postgres_apt_repo }}"
+  ansible.builtin.deb822_repository:
+    name: postgres
+    types:
+      - deb
+      - deb-src
+    uris: "{{ postgres_apt_repo }}"
+    suites: "{{ ansible_facts['distribution_release'] }}-pgdg"
+    components:
+      - main
+    signed_by: "{{ postgres_apt_repo_gpg }}"
   become: true
+  register: postgres_repo_result
+
+- name: Update apt cache if needed
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
+  when: postgres_repo_result.changed
 
 - name: Install the postgresql package
   ansible.builtin.apt:

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -61,7 +61,7 @@
   ansible.builtin.include_tasks:
     file: restore.yml
   with_items: "{{ postgres_users }}"
-  when: item.backup_restore is defined and item.backup_restore
+  when: item.backup_restore is defined and item.backup_restore | length > 0
 
 - name: Install the script for backup rotation
   ansible.builtin.copy:
@@ -83,7 +83,7 @@
     dest: /usr/lib/systemd/system/postgres-backups@{{ item.database }}.timer
     mode: 'u=rw,g=r,o=r'
   with_items: "{{ postgres_users }}"
-  when: item.backup_schedule is defined and item.backup_schedule
+  when: item.backup_schedule is defined and item.backup_schedule | length > 0
   become: true
 
 - name: Enable timers triggering backups of postgresql databases
@@ -92,5 +92,5 @@
     state: started
     enabled: true
   with_items: "{{ postgres_users }}"
-  when: item.backup_schedule is defined and item.backup_schedule
+  when: item.backup_schedule is defined and item.backup_schedule | length > 0
   become: true

--- a/roles/postgres/tasks/restore.yml
+++ b/roles/postgres/tasks/restore.yml
@@ -10,26 +10,26 @@
         query: "SELECT * FROM pg_catalog.pg_tables WHERE tableowner = %s"
         positional_args:
           - "{{ item.username }}"
-      register: existing_tables
+      register: postgres_existing_tables
 
     - name: Copy and restore a database backup (only if the database is empty)
-      when: existing_tables.rowcount == 0
+      when: postgres_existing_tables.rowcount == 0
       block:
         - name: Create a temporary backup directory
           ansible.builtin.tempfile:
             state: directory
             suffix: backup
-          register: backup_tmp_dir
+          register: postgres_backup_tmp_dir
 
         - name: Copy the database backup
           ansible.builtin.copy:
             src: "{{ item.backup_restore }}"
-            dest: "{{ [backup_tmp_dir.path, item.backup_restore | basename] | path_join }}"
+            dest: "{{ [postgres_backup_tmp_dir.path, item.backup_restore | basename] | path_join }}"
             mode: 'u=rw,g=r,o='
 
         - name: Restore the database backup
           community.postgresql.postgresql_db:
             name: "{{ item.database }}"
             state: "restore"
-            target: "{{ [backup_tmp_dir.path, item.backup_restore | basename] | path_join }}"
+            target: "{{ [postgres_backup_tmp_dir.path, item.backup_restore | basename] | path_join }}"
             target_opts: "--single-transaction --exit-on-error"

--- a/roles/postgres/vars/main.yml
+++ b/roles/postgres/vars/main.yml
@@ -4,7 +4,5 @@ postgres_apt_prerequisite_packages:
   - debian-keyring
   - debian-archive-keyring
   - apt-transport-https
-postgres_apt_repo:
-  - deb https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main
-  - deb-src https://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main
+postgres_apt_repo: https://apt.postgresql.org/pub/repos/apt/
 postgres_apt_repo_gpg: https://www.postgresql.org/media/keys/ACCC4CF8.asc

--- a/roles/volume/tasks/main.yml
+++ b/roles/volume/tasks/main.yml
@@ -2,12 +2,12 @@
 
 - name: Check if the external volume already has a filesystem
   ansible.builtin.command: "lsblk --fs --json {{ volume_device }}"
-  register: lsblk
+  register: volume_lsblk
   changed_when: false
 
 - name: Check if the external volume already has a filesystem
   ansible.builtin.set_fact:
-    volume_has_fs: "{{ (lsblk.stdout | from_json)['blockdevices'][0]['fstype'] is not none }}"
+    volume_has_fs: "{{ (volume_lsblk.stdout | from_json)['blockdevices'][0]['fstype'] is not none }}"
 
 - name: If not, create a new filesystem
   ansible.builtin.command: "mkfs.{{ volume_fs }} {{ volume_device }}"

--- a/site.yml
+++ b/site.yml
@@ -10,7 +10,9 @@
     # https://docs.ansible.com/ansible-core/2.12/user_guide/become.html#risks-of-becoming-an-unprivileged-user
     - name: Install prerequisite packages
       ansible.builtin.apt:
-        name: acl
+        name:
+          - acl
+          - python3-debian
         state: present
       become: true
 


### PR DESCRIPTION
`apt-key` is deprecated and is going to be removed in the next Debian stable release. The suggested migration path is to use the so called DEB822 source format. Among other things, this new format allows to specify the package signing key. Conveniently, Ansible provides a module that supports DEB822-style source definitions.

Configured keys are fetched and stashed in `/etc/apt/trusted.gpg.d`, similarly to how this was handled with `apt-key`. The crucial difference is that the scope of each key is limited to a single source now.

---

This also includes minor changes to make the linter happy and fix the playbook execution on recent Ansible versions. See the inline comments and individual commits for details.